### PR TITLE
Print task lists non-interactively to stdout

### DIFF
--- a/internal/colors/colors.go
+++ b/internal/colors/colors.go
@@ -18,28 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package models
+// package colors defines all color values
+// used by the application.
+package colors
 
-import (
-	"time"
+import "github.com/charmbracelet/lipgloss"
 
-	tea "github.com/charmbracelet/bubbletea"
+var (
+	Red      = lipgloss.AdaptiveColor{Light: "#FE5F86", Dark: "#FE5F86"}
+	VividRed = lipgloss.AdaptiveColor{Light: "#FE134D", Dark: "#FE134D"}
+	Indigo   = lipgloss.AdaptiveColor{Light: "#5A56E0", Dark: "#7571F9"}
+	Green    = lipgloss.AdaptiveColor{Light: "#02BA84", Dark: "#02BF87"}
+	Orange   = lipgloss.AdaptiveColor{Light: "#FFB733", Dark: "#FFA336"}
+	Blue     = lipgloss.AdaptiveColor{Light: "#1e90ff", Dark: "#1e90ff"}
+	Yellow   = lipgloss.AdaptiveColor{Light: "#CCCC00", Dark: "#CCCC00"}
+	Black    = lipgloss.Color("#000000")
 )
-
-// completedString returns a string representation of the task completion state.
-// It returns "done" if completed is true, otherwise "open".
-func completedString(completed bool) string {
-	if completed {
-		return "done"
-	}
-
-	return "open"
-}
-
-// tickCmd returns a Bubble Tea command that sends a tickMsg every second.
-// Used to drive periodic updates in the TUI, such as progress animations.
-func tickCmd() tea.Cmd {
-	return tea.Tick(time.Second*1, func(t time.Time) tea.Msg {
-		return tickMsg(t)
-	})
-}

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -1,0 +1,89 @@
+// Copyright 2025 handlebargh
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// package helpers defines some functions
+// used by several other packages.
+package helpers
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/handlebargh/yatto/internal/colors"
+	"github.com/handlebargh/yatto/internal/items"
+	"github.com/spf13/viper"
+)
+
+// ReadProjectsFromFS reads all project directories from the configured storage path.
+// It deserializes each project's `project.json` file into an items.Project object.
+// Returns a slice of all successfully read projects.
+// Panics if the storage directory can't be read or if project files are invalid.
+func ReadProjectsFromFS() []items.Project {
+	storageDir := viper.GetString("storage.path")
+	entries, err := os.ReadDir(storageDir)
+	if err != nil {
+		panic(fmt.Errorf("fatal error reading storage directory: %w", err))
+	}
+
+	var projects []items.Project
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == ".git" {
+			continue
+		}
+
+		dirPath := filepath.Join(storageDir, entry.Name())
+
+		projectFile, err := os.ReadFile(filepath.Join(dirPath, "project.json"))
+		if err != nil {
+			panic(err)
+		}
+
+		var project items.Project
+		if err := json.Unmarshal(projectFile, &project); err != nil {
+			panic(err)
+		}
+		projects = append(projects, project)
+	}
+
+	return projects
+}
+
+// GetColorCode maps a project color name to its corresponding lipgloss.AdaptiveColor.
+// Supported colors include: green, orange, red, blue, indigo.
+// Defaults to blue if the color is unrecognized.
+func GetColorCode(color string) lipgloss.AdaptiveColor {
+	switch color {
+	case "green":
+		return colors.Green
+	case "orange":
+		return colors.Orange
+	case "red":
+		return colors.Red
+	case "blue":
+		return colors.Blue
+	case "indigo":
+		return colors.Indigo
+	default:
+		return colors.Blue
+	}
+}

--- a/internal/models/definitions.go
+++ b/internal/models/definitions.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/handlebargh/yatto/internal/colors"
 )
 
 type (
@@ -52,34 +53,23 @@ const (
 )
 
 var (
-	red      = lipgloss.AdaptiveColor{Light: "#FE5F86", Dark: "#FE5F86"}
-	vividRed = lipgloss.AdaptiveColor{Light: "#FE134D", Dark: "#FE134D"}
-	indigo   = lipgloss.AdaptiveColor{Light: "#5A56E0", Dark: "#7571F9"}
-	green    = lipgloss.AdaptiveColor{Light: "#02BA84", Dark: "#02BF87"}
-	orange   = lipgloss.AdaptiveColor{Light: "#FFB733", Dark: "#FFA336"}
-	blue     = lipgloss.AdaptiveColor{Light: "#1e90ff", Dark: "#1e90ff"}
-	yellow   = lipgloss.AdaptiveColor{Light: "#CCCC00", Dark: "#CCCC00"}
-	black    = lipgloss.Color("#000000")
-)
-
-var (
 	// appStyle defines the base padding for the entire application.
 	appStyle = lipgloss.NewStyle().Padding(1, 2)
 
 	// titleStyleProjects styles the title header for the project list.
 	titleStyleProjects = lipgloss.NewStyle().
 				Foreground(lipgloss.Color("#000000")).
-				Background(green).
+				Background(colors.Green).
 				Padding(0, 1)
 
 		// textStyleGreen renders strings using the green foreground color.
 	textStyleGreen = lipgloss.NewStyle().
-			Foreground(green).
+			Foreground(colors.Green).
 			Render
 
 		// textStyleRed renders strings using the red foreground color.
 	textStyleRed = lipgloss.NewStyle().
-			Foreground(red).
+			Foreground(colors.Red).
 			Render
 )
 
@@ -124,7 +114,7 @@ func NewStyles(lg *lipgloss.Renderer) *Styles {
 	s.Highlight = lg.NewStyle().
 		Foreground(lipgloss.Color("212"))
 	s.ErrorHeaderText = s.HeaderText.
-		Foreground(red)
+		Foreground(colors.Red)
 	s.Help = lg.NewStyle().
 		Foreground(lipgloss.Color("240"))
 	return &s

--- a/internal/models/projectForm.go
+++ b/internal/models/projectForm.go
@@ -28,6 +28,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/handlebargh/yatto/internal/colors"
 	"github.com/handlebargh/yatto/internal/git"
 	"github.com/handlebargh/yatto/internal/items"
 	"github.com/handlebargh/yatto/internal/storage"
@@ -264,9 +265,9 @@ func (m projectFormModel) errorView() string {
 func (m projectFormModel) appBoundaryView(text string) string {
 	var color lipgloss.AdaptiveColor
 	if m.edit {
-		color = orange
+		color = colors.Orange
 	} else {
-		color = green
+		color = colors.Green
 	}
 
 	return lipgloss.PlaceHorizontal(
@@ -285,6 +286,6 @@ func (m projectFormModel) appErrorBoundaryView(text string) string {
 		lipgloss.Left,
 		m.styles.ErrorHeaderText.Render(text),
 		lipgloss.WithWhitespaceChars("❯"),
-		lipgloss.WithWhitespaceForeground(red),
+		lipgloss.WithWhitespaceForeground(colors.Red),
 	)
 }

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -33,6 +33,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
 	"github.com/handlebargh/yatto/internal/git"
+	"github.com/handlebargh/yatto/internal/helpers"
 	"github.com/handlebargh/yatto/internal/items"
 )
 
@@ -92,7 +93,7 @@ func (d customProjectDelegate) Render(w io.Writer, m list.Model, index int, item
 		return
 	}
 
-	color := getColorCode(projectItem.Color())
+	color := helpers.GetColorCode(projectItem.Color())
 
 	// Base styles.
 	listItemStyle := lipgloss.NewStyle().
@@ -173,7 +174,7 @@ type projectListModel struct {
 func InitialProjectListModel() projectListModel {
 	listKeys := newProjectListKeyMap()
 
-	projects := readProjectsFromFS()
+	projects := helpers.ReadProjectsFromFS()
 	items := []list.Item{}
 
 	for _, project := range projects {

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -29,6 +29,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/handlebargh/yatto/internal/colors"
 	"github.com/handlebargh/yatto/internal/git"
 	"github.com/handlebargh/yatto/internal/items"
 	"github.com/handlebargh/yatto/internal/storage"
@@ -290,30 +291,30 @@ func (m taskFormModel) View() string {
 	// Status (right side)
 	switch m.vars.taskPriority {
 	case "high":
-		s.Priority = s.Priority.Background(red)
+		s.Priority = s.Priority.Background(colors.Red)
 	case "medium":
-		s.Priority = s.Priority.Background(orange)
+		s.Priority = s.Priority.Background(colors.Orange)
 	case "low":
-		s.Priority = s.Priority.Background(indigo)
+		s.Priority = s.Priority.Background(colors.Indigo)
 	default:
-		s.Priority = s.Priority.Background(indigo)
+		s.Priority = s.Priority.Background(colors.Indigo)
 	}
 
 	switch m.vars.taskCompleted {
 	case true:
-		s.Completed = s.Completed.Background(green)
+		s.Completed = s.Completed.Background(colors.Green)
 	case false:
-		s.Completed = s.Completed.Background(blue)
+		s.Completed = s.Completed.Background(colors.Blue)
 	}
 
 	var header string
 	var color lipgloss.AdaptiveColor
 	if m.edit {
 		header = m.appBoundaryView("Edit task")
-		color = orange
+		color = colors.Orange
 	} else {
 		header = m.appBoundaryView("Create new task")
-		color = green
+		color = colors.Green
 	}
 
 	var status string
@@ -361,9 +362,9 @@ func (m taskFormModel) errorView() string {
 func (m taskFormModel) appBoundaryView(text string) string {
 	var color lipgloss.AdaptiveColor
 	if m.edit {
-		color = orange
+		color = colors.Orange
 	} else {
-		color = green
+		color = colors.Green
 	}
 
 	return lipgloss.PlaceHorizontal(
@@ -382,6 +383,6 @@ func (m taskFormModel) appErrorBoundaryView(text string) string {
 		lipgloss.Left,
 		m.styles.ErrorHeaderText.Render(text),
 		lipgloss.WithWhitespaceChars("❯"),
-		lipgloss.WithWhitespaceForeground(red),
+		lipgloss.WithWhitespaceForeground(colors.Red),
 	)
 }

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -34,7 +34,9 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
+	"github.com/handlebargh/yatto/internal/colors"
 	"github.com/handlebargh/yatto/internal/git"
+	"github.com/handlebargh/yatto/internal/helpers"
 	"github.com/handlebargh/yatto/internal/items"
 )
 
@@ -118,29 +120,29 @@ func (d customTaskDelegate) Render(w io.Writer, m list.Model, index int, item li
 		Width(60)
 
 	labelsStyle := lipgloss.NewStyle().
-		Foreground(blue).
+		Foreground(colors.Blue).
 		Padding(0, 1)
 
 	priorityValueStyle := lipgloss.NewStyle().
-		Foreground(black).
+		Foreground(colors.Black).
 		Padding(0, 1)
 
 	switch taskItem.Priority() {
 	case "low":
-		titleStyle = titleStyle.BorderForeground(indigo)
-		labelsStyle = labelsStyle.BorderForeground(indigo)
+		titleStyle = titleStyle.BorderForeground(colors.Indigo)
+		labelsStyle = labelsStyle.BorderForeground(colors.Indigo)
 		priorityValueStyle = priorityValueStyle.
-			BorderForeground(indigo).Background(indigo)
+			BorderForeground(colors.Indigo).Background(colors.Indigo)
 	case "medium":
-		titleStyle = titleStyle.BorderForeground(orange)
-		labelsStyle = labelsStyle.BorderForeground(orange)
+		titleStyle = titleStyle.BorderForeground(colors.Orange)
+		labelsStyle = labelsStyle.BorderForeground(colors.Orange)
 		priorityValueStyle = priorityValueStyle.
-			BorderForeground(orange).Background(orange)
+			BorderForeground(colors.Orange).Background(colors.Orange)
 	case "high":
-		titleStyle = titleStyle.BorderForeground(red)
-		labelsStyle = labelsStyle.BorderForeground(red)
+		titleStyle = titleStyle.BorderForeground(colors.Red)
+		labelsStyle = labelsStyle.BorderForeground(colors.Red)
 		priorityValueStyle = priorityValueStyle.
-			BorderForeground(red).Background(red)
+			BorderForeground(colors.Red).Background(colors.Red)
 	}
 
 	if index == m.Index() {
@@ -168,24 +170,24 @@ func (d customTaskDelegate) Render(w io.Writer, m list.Model, index int, item li
 		dueDate.After(now) {
 		right = right + lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(vividRed).
-			Foreground(black).
+			Background(colors.VividRed).
+			Foreground(colors.Black).
 			Render("due today")
 	}
 
 	if dueDate != nil && dueDate.Before(now) {
 		right = right + lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(vividRed).
-			Foreground(black).
+			Background(colors.VividRed).
+			Foreground(colors.Black).
 			Render("overdue")
 	}
 
 	if taskItem.InProgress() {
 		right = right + lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(blue).
-			Foreground(black).
+			Background(colors.Blue).
+			Foreground(colors.Black).
 			Render("in progress")
 	}
 
@@ -194,16 +196,16 @@ func (d customTaskDelegate) Render(w io.Writer, m list.Model, index int, item li
 		!items.IsToday(dueDate) {
 		right = right + lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(yellow).
-			Foreground(black).
+			Background(colors.Yellow).
+			Foreground(colors.Black).
 			Render("due in "+taskItem.DaysUntilToString()+" days")
 	}
 
 	if taskItem.Completed() {
 		right = lipgloss.NewStyle().
 			Padding(0, 1).
-			Background(green).
-			Foreground(black).
+			Background(colors.Green).
+			Foreground(colors.Black).
 			Render("done")
 	}
 
@@ -244,7 +246,7 @@ func newTaskListModel(project *items.Project, projectModel *projectListModel) ta
 		items = append(items, &task)
 	}
 
-	color := getColorCode(project.Color())
+	color := helpers.GetColorCode(project.Color())
 
 	titleStyleTasks := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("#000000")).

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -1,0 +1,127 @@
+// Copyright 2025 handlebargh
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// package printer provides the logic to print task lists
+// in a non-interactive way to stdout.
+package printer
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/handlebargh/yatto/internal/colors"
+	"github.com/handlebargh/yatto/internal/helpers"
+	"github.com/handlebargh/yatto/internal/items"
+)
+
+// projectTask represents a single task along with the project it belongs to.
+// It is used to keep project context when working with individual tasks.
+type projectTask struct {
+	project items.Project
+	task    items.Task
+}
+
+// getProjectTasks retrieves tasks from the filesystem for the given project IDs.
+//
+// If no project IDs are provided, it returns tasks from all available projects.
+// For each task, the associated project is also returned via the projectTask type.
+//
+// It returns two values:
+//   - A slice of projectTask, each containing a task and its corresponding project.
+//   - A slice of strings representing project IDs that were requested but not found.
+func getProjectTasks(projectsIDs ...string) ([]projectTask, []string) {
+	projects := helpers.ReadProjectsFromFS()
+
+	foundIDs := make(map[string]bool)
+	var result []projectTask
+
+	for _, project := range projects {
+		id := project.Id()
+		if len(projectsIDs) == 0 || slices.Contains(projectsIDs, id) {
+			foundIDs[id] = true
+			for _, task := range project.ReadTasksFromFS() {
+				result = append(result, projectTask{
+					project: project,
+					task:    task,
+				})
+			}
+		}
+	}
+
+	var missing []string
+	if len(projectsIDs) > 0 {
+		for _, id := range projectsIDs {
+			if !foundIDs[id] {
+				missing = append(missing, id)
+			}
+		}
+	}
+
+	return result, missing
+}
+
+// PrintTasks prints tasks to the terminal in a stylized, non-interactive format.
+//
+// If project IDs are provided, it only prints tasks from those projects.
+// If no project IDs are given, it prints tasks from all projects.
+//
+// If any provided project ID does not exist, an error message is printed to the terminal
+// indicating which project IDs were not found.
+func PrintTasks(projectsIDs ...string) {
+	pt, missing := getProjectTasks(projectsIDs...)
+
+	if len(missing) > 0 {
+		for _, projectId := range missing {
+			fmt.Println(
+				lipgloss.NewStyle().
+					Foreground(colors.Red).
+					Render(fmt.Sprintf("\nerror: project ID %s not found\n", projectId)),
+			)
+		}
+	}
+
+	for _, pt := range pt {
+
+		taskTitle := pt.task.CropTaskTitle(30)
+		projectTitle := lipgloss.NewStyle().
+			Foreground(helpers.GetColorCode(pt.project.Color())).
+			Render(pt.project.Title())
+
+		var taskLabels string
+		if len(pt.task.Labels()) > 0 {
+			taskLabels = lipgloss.NewStyle().
+				Foreground(colors.Blue).
+				Render("\n\t" + pt.task.CropTaskLabels(30))
+		}
+
+		left := lipgloss.NewStyle().Render(
+			"\n\t" +
+				taskTitle + "\n\t" +
+				projectTitle +
+				taskLabels)
+
+		right := lipgloss.NewStyle().Render()
+
+		row := lipgloss.JoinHorizontal(lipgloss.Top, left, right)
+
+		fmt.Println(row)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strings"
 
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
@@ -36,6 +37,7 @@ import (
 	"github.com/handlebargh/yatto/internal/config"
 	"github.com/handlebargh/yatto/internal/git"
 	"github.com/handlebargh/yatto/internal/models"
+	"github.com/handlebargh/yatto/internal/printer"
 	"github.com/handlebargh/yatto/internal/storage"
 	"github.com/spf13/viper"
 )
@@ -192,6 +194,8 @@ func initConfig(home string, configPath *string) {
 func main() {
 	configPath := flag.String("config", "", "Path to the config file")
 	versionFlag := flag.Bool("version", false, "Print application version")
+	printFlag := flag.Bool("print", false, "Print tasks to stdout")
+	printProjects := flag.String("projects", "", "List of project UUIDs to print from")
 	flag.Parse()
 
 	if *versionFlag {
@@ -208,6 +212,14 @@ func main() {
 	initConfig(home, configPath)
 	config.CreateConfigFile(home)
 	storage.CreateStorageDir()
+
+	if *printFlag {
+		// Get a slice of strings from user input.
+		projects := strings.Fields(*printProjects)
+
+		printer.PrintTasks(projects...)
+		os.Exit(0)
+	}
 
 	if viper.GetBool("git.remote.enable") {
 		s := spinner.New()


### PR DESCRIPTION
This PR adds a new package called printer that allows to run yatto with a `-print` flag to print task lists to stdout. This can for instance be used in /etc/motd to get a quick overview of open tasks when starting a new terminal session.

**Current status:**

* `-print` will print all tasks of all projects
* when `-project $projectId1 $projectId2 ...` is added, yatto will print tasks associated to these projects only.
* if a project ID is passed that cannot be found an error message will be printed

**What's still todo:**

* done tasks should not be printed
* tasks should be sorted by due date by default
* tasks may be sorted by other criteria controlled by users via flag
* tasks should be able to be filtered by users (e.g. by regex)

As a side note:

I created a separate package for the colors used by yatto. This may be useful to allow users to set the colors by themselves via config file.