### PR TITLE
fix: use viewport model on task preview box

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/charmbracelet/huh v0.7.0
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250404203927-76690c660834
 	github.com/google/uuid v1.6.0
+	github.com/muesli/reflow v0.3.0
 	github.com/spf13/viper v1.20.1
 )
 
@@ -39,7 +40,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.2 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -177,10 +177,6 @@ func newTaskFormModel(t *items.Task, listModel *taskListModel, edit bool) taskFo
 		WithShowErrors(false).
 		WithTheme(colors.FormTheme())
 
-	// Workaround for a problem that prevents the form
-	// from being initially completely rendered.
-	m.form.PrevField()
-
 	return m
 }
 

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -284,8 +284,6 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				)
 				m.listModel.status = ""
 
-			} else {
-				return m.listModel, tea.WindowSize()
 			}
 
 			return m.listModel, tea.Batch(cmds...)

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -245,7 +245,7 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.cancel = true
 
 			var err error
-			m.task, err = formVarsToTask(m.vars)
+			m.task, err = formVarsToTask(m.task, m.vars)
 			if err != nil {
 				// TODO: we should probably return a message here.
 				return m, nil
@@ -256,7 +256,7 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		if m.form.State == huh.StateCompleted {
 			var err error
-			m.task, err = formVarsToTask(m.vars)
+			m.task, err = formVarsToTask(m.task, m.vars)
 			if err != nil {
 				// TODO: we should probably return a message here.
 				return m, nil
@@ -436,18 +436,17 @@ func (m taskFormModel) generatePreviewContent() string {
 		wordwrap.String(m.vars.taskDescription, previewWidth-previewContentPadding)
 }
 
-// formVarsToTask converts form input variables into a Task object.
+// formVarsToTask populates an existing Task object using values from a taskFormVars struct.
 //
-// It maps the fields from the provided taskFormVars struct to a new items.Task,
-// setting the title, description, priority, labels, and completion status.
+// It sets the task's title, description, priority, labels, and completion status
+// using the corresponding fields from the form input.
 //
-// If a due date string is provided, it attempts to parse it using the local
-// time zone. If parsing fails or the time zone cannot be loaded, an error is returned.
+// If a due date string is provided, it attempts to parse it using the local time zone.
+// If parsing succeeds, the due date is set; otherwise, an error is returned. If no due date
+// is provided, the task's due date is cleared.
 //
-// Returns the constructed *items.Task and any error encountered during date parsing.
-func formVarsToTask(v *taskFormVars) (*items.Task, error) {
-	var t items.Task
-
+// Returns the updated *items.Task and any error encountered during date parsing or time zone loading.
+func formVarsToTask(t *items.Task, v *taskFormVars) (*items.Task, error) {
 	t.SetTitle(v.taskTitle)
 	t.SetDescription(v.taskDescription)
 	t.SetPriority(v.taskPriority)
@@ -458,12 +457,12 @@ func formVarsToTask(v *taskFormVars) (*items.Task, error) {
 		// Get the local time zone
 		location, err := time.LoadLocation("Local")
 		if err != nil {
-			return &t, err
+			return t, err
 		}
 
 		date, err := time.ParseInLocation(time.DateTime, v.taskDueDate, location)
 		if err != nil {
-			return &t, err
+			return t, err
 		}
 
 		t.SetDueDate(&date)
@@ -471,5 +470,5 @@ func formVarsToTask(v *taskFormVars) (*items.Task, error) {
 		t.SetDueDate(nil)
 	}
 
-	return &t, nil
+	return t, nil
 }

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -283,7 +283,6 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					),
 				)
 				m.listModel.status = ""
-
 			}
 
 			return m.listModel, tea.Batch(cmds...)

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -412,6 +412,14 @@ func (m taskFormModel) appErrorBoundaryView(text string) string {
 	)
 }
 
+// generatePreviewContent generates the formatted string content for the task preview pane.
+// It includes the task title, priority, completion status, and description, all styled
+// and wrapped to fit within the width of the preview viewport.
+//
+// The title line is rendered with appropriate styles for title, priority, and completion status,
+// and both the title and description are word-wrapped to avoid overflow.
+//
+// Returns the full preview string, ready to be set as the viewport's content.
 func (m taskFormModel) generatePreviewContent() string {
 	title := fmt.Sprintf("%s %s %s",
 		m.styles.Title.Render(m.vars.taskTitle),

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -39,16 +39,20 @@ import (
 )
 
 const (
-	// previewWidth holds the width of the task preview box.
+	// previewWidth defines the width of the task preview box.
 	previewWidth = 40
 
 	// previewVerticalPadding positions the status box
-	// between header and footer
+	// between header and footer.
 	previewVerticalPadding = 10
 
 	// previewContentPadding centers text horizontally inside
-	// the staus box
+	// the staus box.
 	previewContentPadding = 3
+
+	// previewLinesToScroll defines how many lines
+	// to scroll when pressing pageUP/pageDOWN.
+	previewLinesToScroll = 5
 )
 
 // taskFormModel defines the Bubble Tea model for a form-based interface
@@ -215,11 +219,11 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Scroll the preview box
 		switch msg.Type {
 		case tea.KeyPgUp:
-			m.previewViewport.ScrollUp(5)
+			m.previewViewport.ScrollUp(previewLinesToScroll)
 			m.previewViewport.SetContent(m.generatePreviewContent())
 			m.userScrolled = true
 		case tea.KeyPgDown:
-			m.previewViewport.ScrollDown(5)
+			m.previewViewport.ScrollDown(previewLinesToScroll)
 			m.previewViewport.SetContent(m.generatePreviewContent())
 			m.userScrolled = true
 		}

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -225,7 +225,12 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case tea.KeyPgDown:
 			m.previewViewport.ScrollDown(previewLinesToScroll)
 			m.previewViewport.SetContent(m.generatePreviewContent())
-			m.userScrolled = true
+
+			if m.previewViewport.AtBottom() {
+				m.userScrolled = false // Re-enable auto-scroll
+			} else {
+				m.userScrolled = true
+			}
 		}
 
 		if m.cancel {

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -253,39 +253,41 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 			return m, nil
 		}
+	}
 
-		if m.form.State == huh.StateCompleted {
-			err := m.formVarsToTask()
-			if err != nil {
-				// TODO: we should probably return a message here.
-				return m, nil
-			}
-
-			// Write task only if form has been confirmed.
-			if m.vars.confirm {
-				json := m.task.MarshalTask()
-
-				taskPath := filepath.Join(m.listModel.project.Id(), m.task.Id()+".json")
-
-				action := "create"
-				if storage.FileExists(taskPath) {
-					action = "update"
-				}
-				cmds = append(
-					cmds,
-					m.listModel.progress.SetPercent(0.10),
-					tickCmd(),
-					m.task.WriteTaskJson(json, *m.listModel.project, action),
-					git.CommitCmd(
-						taskPath,
-						fmt.Sprintf("%s: %s", action, m.task.Title()),
-					),
-				)
-				m.listModel.status = ""
-			}
-
-			return m.listModel, tea.Batch(cmds...)
+	if m.form.State == huh.StateCompleted {
+		err := m.formVarsToTask()
+		if err != nil {
+			// TODO: we should probably return a message here.
+			return m, nil
 		}
+
+		// Write task only if form has been confirmed.
+		if m.vars.confirm {
+			json := m.task.MarshalTask()
+
+			taskPath := filepath.Join(m.listModel.project.Id(), m.task.Id()+".json")
+
+			action := "create"
+			if storage.FileExists(taskPath) {
+				action = "update"
+			}
+			cmds = append(
+				cmds,
+				m.listModel.progress.SetPercent(0.10),
+				tickCmd(),
+				m.task.WriteTaskJson(json, *m.listModel.project, action),
+				git.CommitCmd(
+					taskPath,
+					fmt.Sprintf("%s: %s", action, m.task.Title()),
+				),
+			)
+			m.listModel.status = ""
+		} else {
+			return m.listModel, nil
+		}
+
+		return m.listModel, tea.Batch(cmds...)
 	}
 
 	return m, tea.Batch(cmds...)


### PR DESCRIPTION
This PR solves the problem we have with overflowing task preview boxes by using the viewport model on the box.
Focus can now be switched from the form to the preview box by pressing tab. However, I'm open for suggestions on changing the key bind, as tab may not be the ideal choice. 

When focus is on the box it can be scrolled by pressing j,k,up,down,pgup,pgdown,g,G -> pretty much everything that comes to mind. The box does auto-scrolling too, when new input is entered.

I want to add one more thing before this is ready to merge. I want the box's border color to change when it is in focus.