### PR TITLE
Feat/suggest labels

### DIFF
--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -84,7 +84,7 @@ func ReadProjectsFromFS() []items.Project {
 //
 // Errors encountered while reading or parsing individual files are logged
 // to standard error, but do not stop processing of other files.
-func GetAllLabels() map[string]int {
+func AllLabels() map[string]int {
 	storageDir := viper.GetString("storage.path")
 
 	// Store labels in a map and track their occurrence.

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -118,7 +118,7 @@ func GetAllLabels() map[string]int {
 			return nil
 		}
 
-		for _, label := range labelsStringToSlice(task.Labels) {
+		for _, label := range LabelsStringToSlice(task.Labels) {
 			labelCount[label]++
 		}
 
@@ -140,7 +140,7 @@ func GetAllLabels() map[string]int {
 //	input := "work, urgent ,home "
 //	output := labelsStringToSlice(input)
 //	// output: []string{"work", "urgent", "home"}
-func labelsStringToSlice(labels string) []string {
+func LabelsStringToSlice(labels string) []string {
 	var result []string
 
 	for _, label := range strings.Split(labels, ",") {

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -70,7 +70,7 @@ func ReadProjectsFromFS() []items.Project {
 	return projects
 }
 
-// GetAllLabels walks the task storage directory (as configured by the
+// AllLabels walks the task storage directory (as configured by the
 // "storage.path" setting in Viper), reads all task JSON files whose
 // filenames match the UUID pattern, and extracts their labels.
 //

--- a/internal/items/helpers.go
+++ b/internal/items/helpers.go
@@ -20,7 +20,14 @@
 
 package items
 
-import "time"
+import (
+	"regexp"
+	"time"
+)
+
+var UUIDRegex = regexp.MustCompile(
+	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\.json$`,
+)
 
 // IsToday returns true if the given time is not nil and falls on today's date
 // (year, month, and day match the current local date). Returns false if the

--- a/internal/items/project.go
+++ b/internal/items/project.go
@@ -103,7 +103,7 @@ func (p *Project) ReadTasksFromFS() []Task {
 
 	var tasks []Task
 	for _, entry := range taskFiles {
-		if entry.IsDir() || !uuidRegex.MatchString(entry.Name()) {
+		if entry.IsDir() || !UUIDRegex.MatchString(entry.Name()) {
 			continue
 		}
 

--- a/internal/items/task.go
+++ b/internal/items/task.go
@@ -149,14 +149,16 @@ func (t Task) CropTaskTitle(length int) string {
 	return t.TaskTitle
 }
 
-// CropTaskLabels returns the task's labels cropped to fit
-// length with a concatenated ellipses.
+// CropTaskLabels returns the task's labels as string.
+// Labels are separated by comma + whitespace.
+// If the returned string would exceed length
+// it is cropped and an ellipses is appended to fit length.
 func (t Task) CropTaskLabels(length int) string {
 	if len(t.LabelsString()) > length {
-		return t.TaskLabels[:length-len(ellipses)] + ellipses
+		return strings.ReplaceAll(t.TaskLabels[:length-len(ellipses)]+ellipses, ",", ", ")
 	}
 
-	return t.TaskLabels
+	return strings.ReplaceAll(t.TaskLabels, ",", ", ")
 }
 
 // DueDateToString formats the task's due date as a string using DueDateLayout.

--- a/internal/items/task.go
+++ b/internal/items/task.go
@@ -106,11 +106,23 @@ func (t Task) DueDate() *time.Time { return t.TaskDueDate }
 // SetDueDate sets the task's due date.
 func (t *Task) SetDueDate(dueDate *time.Time) { t.TaskDueDate = dueDate }
 
-// Labels returns the task's label string.
-func (t Task) Labels() string { return t.TaskLabels }
+// LabelsString returns the task's label string.
+func (t Task) LabelsString() string { return t.TaskLabels }
 
-// SetLabels sets the task's labels.
-func (t *Task) SetLabels(labels string) { t.TaskLabels = labels }
+// SetLabelsString sets the task's labels string.
+func (t *Task) SetLabelsString(labels string) { t.TaskLabels = labels }
+
+// LabelsList returns the task's labels as slice of string.
+func (t *Task) LabelsList() []string {
+	var result []string
+
+	for _, label := range strings.Split(t.TaskLabels, ",") {
+		if label != "" {
+			result = append(result, strings.TrimSpace(label))
+		}
+	}
+	return result
+}
 
 // InProgress returns true if the task is marked as in progress.
 func (t Task) InProgress() bool { return t.TaskInProgress }
@@ -140,7 +152,7 @@ func (t Task) CropTaskTitle(length int) string {
 // CropTaskLabels returns the task's labels cropped to fit
 // length with a concatenated ellipses.
 func (t Task) CropTaskLabels(length int) string {
-	if len(t.Labels()) > length {
+	if len(t.LabelsString()) > length {
 		return t.TaskLabels[:length-len(ellipses)] + ellipses
 	}
 
@@ -261,9 +273,9 @@ func (t *Task) TaskToMarkdown() string {
 	description := fmt.Sprintf("📝  **Description**\n\n%s\n\n---\n\n", t.Description())
 
 	labels := ""
-	if t.Labels() != "" {
+	if t.LabelsString() != "" {
 		labels = "🏷️  **Labels**\n\n"
-		labelsSeq := strings.SplitSeq(t.Labels(), ",")
+		labelsSeq := strings.SplitSeq(t.LabelsString(), ",")
 		for label := range labelsSeq {
 			labels += "- " + label + "\n\n"
 		}

--- a/internal/items/task.go
+++ b/internal/items/task.go
@@ -31,7 +31,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
@@ -40,10 +39,6 @@ import (
 )
 
 const ellipses = "..."
-
-var uuidRegex = regexp.MustCompile(
-	`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}\.json$`,
-)
 
 type (
 	// WriteTaskJSONDoneMsg indicates successful write of a Task JSON file.

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -190,13 +190,13 @@ func InitialProjectListModel() projectListModel {
 	listKeys := newProjectListKeyMap()
 
 	projects := helpers.ReadProjectsFromFS()
-	items := []list.Item{}
+	listItems := []list.Item{}
 
 	for _, project := range projects {
-		items = append(items, &project)
+		listItems = append(listItems, &project)
 	}
 
-	itemList := list.New(items, customProjectDelegate{DefaultDelegate: list.NewDefaultDelegate()}, 0, 0)
+	itemList := list.New(listItems, customProjectDelegate{DefaultDelegate: list.NewDefaultDelegate()}, 0, 0)
 	itemList.SetShowPagination(true)
 	itemList.SetShowTitle(true)
 	itemList.SetShowStatusBar(true)

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -172,6 +172,7 @@ func (d customProjectDelegate) Render(w io.Writer, m list.Model, index int, item
 type projectListModel struct {
 	list             list.Model
 	selected         bool
+	taskLabels       map[string]int
 	keys             *projectListKeyMap
 	mode             mode
 	err              error
@@ -189,6 +190,7 @@ type projectListModel struct {
 func InitialProjectListModel() projectListModel {
 	listKeys := newProjectListKeyMap()
 
+	// Read all projects from FS to populate project list.
 	projects := helpers.ReadProjectsFromFS()
 	listItems := []list.Item{}
 
@@ -223,16 +225,20 @@ func InitialProjectListModel() projectListModel {
 		}
 	}
 
+	// Read labels from tasks across all projects.
+	labels := helpers.GetAllLabels()
+
 	renderer, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
 	if err != nil {
 		panic(err)
 	}
 
 	return projectListModel{
-		list:     itemList,
-		keys:     listKeys,
-		renderer: renderer,
-		progress: progress.New(progress.WithGradient("#FFA336", "#02BF87")),
+		list:       itemList,
+		taskLabels: labels,
+		keys:       listKeys,
+		renderer:   renderer,
+		progress:   progress.New(progress.WithGradient("#FFA336", "#02BF87")),
 	}
 }
 

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -172,7 +172,6 @@ func (d customProjectDelegate) Render(w io.Writer, m list.Model, index int, item
 type projectListModel struct {
 	list             list.Model
 	selected         bool
-	taskLabels       map[string]int
 	keys             *projectListKeyMap
 	mode             mode
 	err              error
@@ -225,20 +224,16 @@ func InitialProjectListModel() projectListModel {
 		}
 	}
 
-	// Read labels from tasks across all projects.
-	labels := helpers.GetAllLabels()
-
 	renderer, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
 	if err != nil {
 		panic(err)
 	}
 
 	return projectListModel{
-		list:       itemList,
-		taskLabels: labels,
-		keys:       listKeys,
-		renderer:   renderer,
-		progress:   progress.New(progress.WithGradient("#FFA336", "#02BF87")),
+		list:     itemList,
+		keys:     listKeys,
+		renderer: renderer,
+		progress: progress.New(progress.WithGradient("#FFA336", "#02BF87")),
 	}
 }
 

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -106,7 +106,7 @@ func newTaskFormModel(t *items.Task, listModel *taskListModel, edit bool) taskFo
 	m.vars = &v
 	m.task = t
 	m.listModel = listModel
-	m.taskLabels = helpers.GetAllLabels()
+	m.taskLabels = helpers.AllLabels()
 	m.lg = lipgloss.DefaultRenderer()
 	m.styles = NewStyles(m.lg)
 

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -481,7 +481,7 @@ func (m taskFormModel) formVarsToTask() error {
 	}
 
 	// Save as comma-separated string
-	m.task.SetLabelsString(strings.Join(uniqueLabels, ", "))
+	m.task.SetLabelsString(strings.Join(uniqueLabels, ","))
 
 	m.task.SetCompleted(m.vars.taskCompleted)
 

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/handlebargh/yatto/internal/colors"
 	"github.com/handlebargh/yatto/internal/git"
+	"github.com/handlebargh/yatto/internal/helpers"
 	"github.com/handlebargh/yatto/internal/items"
 	"github.com/handlebargh/yatto/internal/storage"
 	"github.com/muesli/reflow/wordwrap"
@@ -61,6 +63,7 @@ type taskFormModel struct {
 	form            *huh.Form
 	task            *items.Task
 	listModel       *taskListModel
+	taskLabels      map[string]int
 	previewViewport viewport.Model
 	userScrolled    bool
 	edit            bool
@@ -74,26 +77,28 @@ type taskFormModel struct {
 // taskFormVars holds the temporary values that are populated and modified
 // in the task form UI.
 type taskFormVars struct {
-	confirm         bool
-	taskTitle       string
-	taskDescription string
-	taskPriority    string
-	taskDueDate     string
-	taskLabels      string
-	taskCompleted   bool
+	confirm            bool
+	taskTitle          string
+	taskDescription    string
+	taskPriority       string
+	taskDueDate        string
+	taskLabels         string
+	taskLabelsSelected []string
+	taskCompleted      bool
 }
 
 // newTaskFormModel initializes and returns a new taskFormModel instance,
 // optionally in edit mode.
 func newTaskFormModel(t *items.Task, listModel *taskListModel, edit bool) taskFormModel {
 	v := taskFormVars{
-		confirm:         true,
-		taskTitle:       t.Title(),
-		taskDescription: t.Description(),
-		taskPriority:    t.Priority(),
-		taskDueDate:     t.DueDateToString(),
-		taskLabels:      t.Labels(),
-		taskCompleted:   t.Completed(),
+		confirm:            true,
+		taskTitle:          t.Title(),
+		taskDescription:    t.Description(),
+		taskPriority:       t.Priority(),
+		taskDueDate:        t.DueDateToString(),
+		taskLabels:         "", // Clear labels as we have them already selected.
+		taskLabelsSelected: t.LabelsList(),
+		taskCompleted:      t.Completed(),
 	}
 
 	m := taskFormModel{}
@@ -101,6 +106,7 @@ func newTaskFormModel(t *items.Task, listModel *taskListModel, edit bool) taskFo
 	m.vars = &v
 	m.task = t
 	m.listModel = listModel
+	m.taskLabels = helpers.GetAllLabels()
 	m.lg = lipgloss.DefaultRenderer()
 	m.styles = NewStyles(m.lg)
 
@@ -136,7 +142,8 @@ func newTaskFormModel(t *items.Task, listModel *taskListModel, edit bool) taskFo
 				Title("Enter a description:\n"+
 					"(markdown is supported)").
 				Value(&m.vars.taskDescription),
-
+		),
+		huh.NewGroup(
 			huh.NewInput().
 				Key("dueDate").
 				Title("Enter a due date:").
@@ -159,13 +166,21 @@ func newTaskFormModel(t *items.Task, listModel *taskListModel, edit bool) taskFo
 
 					return nil
 				}),
+		),
+		huh.NewGroup(
+			huh.NewMultiSelect[string]().
+				Key("existingLabels").
+				Title("Choose labels:").
+				Height(15).
+				OptionsFunc(m.sortLabelsOptions, nil),
 
 			huh.NewInput().
 				Key("labels").
-				Title("Enter labels:").
+				Title("Enter additional labels:").
 				Value(&m.vars.taskLabels).
-				Description("Comma separated list of labels."),
-
+				Description("Comma-separated list of labels."),
+		),
+		huh.NewGroup(
 			huh.NewConfirm().
 				Title(confirmQuestion).
 				Affirmative("Yes").
@@ -431,25 +446,46 @@ func (m taskFormModel) generatePreviewContent() string {
 		wordwrap.String(m.vars.taskDescription, previewWidth-previewContentPadding)
 }
 
-// formVarsToTask updates the associated Task object using values from the taskFormVars struct.
+// formVarsToTask updates the Task object with values from the form variables.
 //
-// It sets the task's title, description, priority, labels, and completion status
-// based on the corresponding fields in the form input.
+// It sets the task's title, description, priority, completion status, and due date.
+// For labels, it merges labels selected via the multi-select widget with additional
+// labels entered as a comma-separated string, deduplicates them (case-insensitive),
+// trims whitespace, and stores them as a single comma-separated string on the task.
 //
-// If a due date string is provided, it attempts to parse it using the local time zone.
-// On successful parsing, the due date is set on the task. If parsing fails, an error is returned.
-// If no due date is provided, the task's due date is cleared (set to nil).
-//
-// Returns an error if the local time zone cannot be loaded or if the due date string cannot be parsed.
+// Returns an error if the due date string cannot be parsed or the local time zone
+// cannot be loaded.
 func (m taskFormModel) formVarsToTask() error {
 	m.task.SetTitle(m.vars.taskTitle)
 	m.task.SetDescription(m.vars.taskDescription)
 	m.task.SetPriority(m.vars.taskPriority)
-	m.task.SetLabels(m.vars.taskLabels)
+
+	// Merge labels from MultiSelect (selected) and freeform input (typed)
+	typedLabels := helpers.LabelsStringToSlice(m.vars.taskLabels)
+	allLabels := append([]string{}, m.form.Get("existingLabels").([]string)...)
+	allLabels = append(allLabels, typedLabels...)
+
+	// Deduplicate (case-insensitive) & trim
+	labelSet := make(map[string]struct{})
+	uniqueLabels := make([]string, 0, len(allLabels))
+	for _, label := range allLabels {
+		l := strings.TrimSpace(label)
+		if l == "" {
+			continue // skip empty labels
+		}
+		key := strings.ToLower(l) // comparison key
+		if _, exists := labelSet[key]; !exists {
+			labelSet[key] = struct{}{}
+			uniqueLabels = append(uniqueLabels, l) // keep original casing
+		}
+	}
+
+	// Save as comma-separated string
+	m.task.SetLabelsString(strings.Join(uniqueLabels, ","))
+
 	m.task.SetCompleted(m.vars.taskCompleted)
 
 	if m.vars.taskDueDate != "" {
-		// Get the local time zone
 		location, err := time.LoadLocation("Local")
 		if err != nil {
 			return err
@@ -466,4 +502,73 @@ func (m taskFormModel) formVarsToTask() error {
 	}
 
 	return nil
+}
+
+// sortLabelsOptions returns a slice of huh.Option[string] representing the task labels,
+// sorted with the following priority:
+//  1. Labels currently selected in the form appear first.
+//  2. Labels are then sorted by descending frequency (most frequent first).
+//  3. Labels with the same frequency are sorted alphabetically (case-insensitive).
+//
+// The function trims whitespace from label keys and ignores empty labels.
+// Selected labels are marked as selected in the returned options.
+//
+// This method converts the internal map of label frequencies into a sorted slice
+// suitable for display in a multi-select UI widget.
+func (m taskFormModel) sortLabelsOptions() []huh.Option[string] {
+	// Convert map to slice of key-value pairs, trimming whitespace and skipping empties
+	type kv struct {
+		Label     string
+		Frequency int
+	}
+
+	var sortedLabels []kv
+	for rawLabel, freq := range m.taskLabels {
+		label := strings.TrimSpace(rawLabel)
+		if label == "" {
+			continue // skip empty labels
+		}
+		sortedLabels = append(sortedLabels, kv{Label: label, Frequency: freq})
+	}
+
+	// Convert selected slice to a set
+	selectedSet := make(map[string]struct{}, len(m.vars.taskLabelsSelected))
+	for _, s := range m.vars.taskLabelsSelected {
+		selectedSet[strings.TrimSpace(s)] = struct{}{}
+	}
+
+	// Sort: selected first, then by frequency descending, then alphabetical
+	slices.SortFunc(sortedLabels, func(a, b kv) int {
+		_, aSelected := selectedSet[a.Label]
+		_, bSelected := selectedSet[b.Label]
+
+		// Selected labels come first
+		if aSelected && !bSelected {
+			return -1
+		}
+
+		if bSelected && !aSelected {
+			return 1
+		}
+
+		// Sort by frequency descending
+		if a.Frequency != b.Frequency {
+			return b.Frequency - a.Frequency
+		}
+
+		// Case-insensitive alphabetical
+		return strings.Compare(strings.ToLower(a.Label), strings.ToLower(b.Label))
+	})
+
+	// Build sorted options
+	opts := make([]huh.Option[string], 0, len(sortedLabels))
+	for _, item := range sortedLabels {
+		opt := huh.NewOption[string](item.Label, item.Label)
+		if _, selected := selectedSet[item.Label]; selected {
+			opt = opt.Selected(true)
+		}
+		opts = append(opts, opt)
+	}
+
+	return opts
 }

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -481,7 +481,7 @@ func (m taskFormModel) formVarsToTask() error {
 	}
 
 	// Save as comma-separated string
-	m.task.SetLabelsString(strings.Join(uniqueLabels, ","))
+	m.task.SetLabelsString(strings.Join(uniqueLabels, ", "))
 
 	m.task.SetCompleted(m.vars.taskCompleted)
 

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -260,10 +260,10 @@ func newTaskListModel(project *items.Project, projectModel *projectListModel) ta
 	listKeys := newTaskListKeyMap()
 
 	tasks := project.ReadTasksFromFS()
-	items := []list.Item{}
+	listItems := []list.Item{}
 
 	for _, task := range tasks {
-		items = append(items, &task)
+		listItems = append(listItems, &task)
 	}
 
 	color := helpers.GetColorCode(project.Color())
@@ -273,7 +273,7 @@ func newTaskListModel(project *items.Project, projectModel *projectListModel) ta
 		Background(color).
 		Padding(0, 1)
 
-	itemList := list.New(items, customTaskDelegate{DefaultDelegate: list.NewDefaultDelegate()}, 0, 0)
+	itemList := list.New(listItems, customTaskDelegate{DefaultDelegate: list.NewDefaultDelegate()}, 0, 0)
 	itemList.SetShowPagination(true)
 	itemList.SetShowTitle(true)
 	itemList.SetShowStatusBar(true)

--- a/internal/printer/printer.go
+++ b/internal/printer/printer.go
@@ -161,7 +161,7 @@ func PrintTasks(labelRegex string, projectsIDs ...string) {
 
 	var pendingTasks []projectTask
 	for _, pt := range pt {
-		if !pt.task.Completed() && regex.MatchString(pt.task.Labels()) {
+		if !pt.task.Completed() && regex.MatchString(pt.task.LabelsString()) {
 			pendingTasks = append(pendingTasks, pt)
 		}
 	}
@@ -176,7 +176,7 @@ func PrintTasks(labelRegex string, projectsIDs ...string) {
 		taskPriority := pt.task.Priority()
 
 		var taskLabels string
-		if len(pt.task.Labels()) > 0 {
+		if len(pt.task.LabelsString()) > 0 {
 			taskLabels = lipgloss.NewStyle().
 				Foreground(colors.Blue()).
 				Render("\n  " + pt.task.CropTaskLabels(40))


### PR DESCRIPTION
# Pull Request Template

## Type of Change

- [ ] Bug fix (non-breaking change)
- [x] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Other

## Description

This PR adds a new feature that allows to choose existing labels at task creation. To achieve this, we have to get all labels at startup (when we create the initial project model) from across all project's tasks. A map of unique labels is stored in the project model, accompanied by a counter storing how often a label has been found.

A multi-select entry will be added to the task form giving users the chance to easily choose from existing task labels. These entries will be sorted by frequency. Additionally users should be able to add new labels to the labels string.

**Note**: Should also take care of duplicate labels. 

Resolves #25 

## How Has This Been Tested?

TODO