### PR TITLE
feat: add Homebrew formula for yatto

### DIFF
--- a/Formula/yatto.rb
+++ b/Formula/yatto.rb
@@ -1,0 +1,24 @@
+class Yatto < Formula
+  desc "Terminal-based to-do application built with Bubble Tea"
+  homepage "https://github.com/handlebargh/yatto"
+  url "https://github.com/handlebargh/yatto/archive/refs/tags/v0.15.0.tar.gz"
+  sha256 "f26896ad3ed339ea51e3eb8d11a8b1c0ce094d28bc6fe4ef0fb9a50daacee5c5"
+  license "MIT"
+
+  depends_on "go" => :build
+
+  def install
+    system "go", "build", *std_go_args(ldflags: "-s -w"), "-o", bin/"yatto"
+  end
+
+  test do
+    # Test version output contains version information
+    output = shell_output("#{bin}/yatto -version")
+    assert_match "Version:", output
+    assert_match "yatto", output
+    
+    # Test help output
+    help_output = shell_output("#{bin}/yatto -help 2>&1", 1)
+    assert_match "Usage of", help_output
+  end
+end


### PR DESCRIPTION
## Summary
- Added `Formula/yatto.rb` to enable Homebrew installation
- Formula downloads source from GitHub v0.15.0 release and builds with Go
- Includes proper SHA256 verification and test suite
- Tested locally - binary builds and passes version/help tests

## What This Enables
Users can now install yatto via Homebrew by running:
```bash
brew tap handlebargh/yatto
brew install yatto
```

## Next Steps for Maintainer

You have two options for keeping the formula updated with new releases:

### Option 1: Manual Updates (Simple)
When you release a new version:
1. Calculate new SHA: `curl -sL https://github.com/handlebargh/yatto/archive/refs/tags/vX.X.X.tar.gz | sha256sum`
2. Update `Formula/yatto.rb` with new version and SHA
3. Commit and push

### Option 2: Automated Updates (Recommended)
Use Homebrew's built-in tooling:
```bash
brew bump-formula-pr --url https://github.com/handlebargh/yatto/archive/refs/tags/vX.X.X.tar.gz handlebargh/yatto/yatto
```

This automatically:
- Calculates the new SHA256
- Updates the formula
- Creates a PR for you to review

### Option 3: GitHub Actions (Advanced)
Set up automation to run `brew bump-formula-pr` on new releases using GitHub Actions.

## Testing
The formula has been tested locally and works correctly. Users will be able to install, upgrade, and uninstall yatto through standard Homebrew commands.

---
*This implementation was created using AI assistance via Claude Code.*