### PR TITLE
Feature: bulk actions

### DIFF
--- a/internal/items/project.go
+++ b/internal/items/project.go
@@ -27,6 +27,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/viper"
 )
@@ -191,4 +192,17 @@ func (p *Project) NumOfTasks() (int, int, int, error) {
 	}
 
 	return total, completed, due, nil
+}
+
+// FindListIndexByID returns the index of the project in the given slice of list.Item,
+// or -1 if not found.
+func (p *Project) FindListIndexByID(items []list.Item) int {
+	for i, item := range items {
+		task, ok := item.(*Project)
+		if ok && task.ID == p.ID {
+			return i
+		}
+	}
+
+	return -1 // not found
 }

--- a/internal/items/task.go
+++ b/internal/items/task.go
@@ -34,6 +34,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/spf13/viper"
 )
@@ -51,7 +52,7 @@ type (
 	WriteTaskJSONErrorMsg struct{ Err error }
 
 	// TaskDeleteDoneMsg indicates successful deletion of a Task from disk.
-	TaskDeleteDoneMsg struct{}
+	TaskDeleteDoneMsg struct{ Task Task }
 
 	// TaskDeleteErrorMsg is returned when a Task fails to delete from disk.
 	TaskDeleteErrorMsg struct{ Err error }
@@ -202,8 +203,21 @@ func (t *Task) DeleteTaskFromFS(p Project) tea.Cmd {
 			return TaskDeleteErrorMsg{err}
 		}
 
-		return TaskDeleteDoneMsg{}
+		return TaskDeleteDoneMsg{*t}
 	}
+}
+
+// FindListIndexByID returns the index of the task in the given slice of list.Item,
+// or -1 if not found.
+func (t *Task) FindListIndexByID(items []list.Item) int {
+	for i, item := range items {
+		task, ok := item.(*Task)
+		if ok && task.ID == t.ID {
+			return i
+		}
+	}
+
+	return -1 // not found
 }
 
 // TaskToMarkdown returns a Markdown-formatted string representing the task,

--- a/internal/models/definitions.go
+++ b/internal/models/definitions.go
@@ -52,26 +52,8 @@ const (
 	modeBackendError
 )
 
-var (
-	// appStyle defines the base padding for the entire application.
-	appStyle = lipgloss.NewStyle().Padding(1, 2)
-
-	// titleStyleProjects styles the title header for the project list.
-	titleStyleProjects = lipgloss.NewStyle().
-				Foreground(colors.BadgeText()).
-				Background(colors.Green()).
-				Padding(0, 1)
-
-	// textStyleGreen renders strings using the green foreground color.
-	textStyleGreen = lipgloss.NewStyle().
-			Foreground(colors.Green()).
-			Render
-
-	// textStyleRed renders strings using the red foreground color.
-	textStyleRed = lipgloss.NewStyle().
-			Foreground(colors.Red()).
-			Render
-)
+// appStyle defines the base padding for the entire application.
+var appStyle = lipgloss.NewStyle().Padding(1, 2)
 
 // Styles defines a reusable collection of lipgloss styles used in task and project forms.
 type Styles struct {

--- a/internal/models/projectForm.go
+++ b/internal/models/projectForm.go
@@ -196,8 +196,8 @@ func (m projectFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			tickCmd(),
 			m.project.WriteProjectJSON(json, action),
 			vcs.CommitCmd(
-				filepath.Join(m.project.ID, "project.json"),
 				fmt.Sprintf("%s: %s", action, m.project.Title),
+				filepath.Join(m.project.ID, "project.json"),
 			),
 		)
 

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -63,7 +63,7 @@ func newProjectListKeyMap() *projectListKeyMap {
 		),
 		deleteProject: key.NewBinding(
 			key.WithKeys("D"),
-			key.WithHelp("D", "delete project"),
+			key.WithHelp("D", "delete selected projects"),
 		),
 		chooseProject: key.NewBinding(
 			key.WithKeys("enter", "l"),
@@ -91,7 +91,7 @@ func newProjectListKeyMap() *projectListKeyMap {
 		),
 		toggleSelect: key.NewBinding(
 			key.WithKeys(" "),
-			key.WithHelp("space", "toggle select"),
+			key.WithHelp("space", "select/deselect"),
 		),
 	}
 }
@@ -540,11 +540,11 @@ func (m ProjectListModel) View() string {
 	if m.mode == modeConfirmDelete {
 		if len(m.selectedItems) > 0 {
 			return centeredStyle.Render(
-				fmt.Sprintf("Delete %d project(s)?\n\n", len(m.selectedItems)) +
-					lipgloss.NewStyle().Foreground(colors.Red()).Render("[y] Yes") +
-					"    " +
-					lipgloss.NewStyle().Foreground(colors.Green()).Render("[n] No"),
-			)
+				fmt.Sprintf("Delete %d project(s)?\n\n%s%s%s", len(m.selectedItems),
+					"[y] Yes",
+					"    ",
+					"[n] No",
+				))
 		}
 	}
 

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -33,6 +33,7 @@ import (
 	"github.com/charmbracelet/glamour"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/google/uuid"
+	"github.com/handlebargh/yatto/internal/colors"
 	"github.com/handlebargh/yatto/internal/helpers"
 	"github.com/handlebargh/yatto/internal/items"
 	"github.com/handlebargh/yatto/internal/vcs"
@@ -135,7 +136,7 @@ func (d customProjectDelegate) Render(w io.Writer, m list.Model, index int, item
 	numTasks, numCompletedTasks, numDueTasks, err := projectItem.NumOfTasks()
 	if err != nil {
 		m.NewStatusMessage(
-			textStyleRed(
+			lipgloss.NewStyle().Foreground(colors.Red()).Render(
 				fmt.Sprintf("Error gathering task info for project %s", projectItem.Title),
 			),
 		)
@@ -144,15 +145,19 @@ func (d customProjectDelegate) Render(w io.Writer, m list.Model, index int, item
 	var taskDueMessage string
 	if numDueTasks > 0 {
 		if numDueTasks == 1 {
-			taskDueMessage = textStyleRed("1 task due today")
+			taskDueMessage = lipgloss.NewStyle().
+				Foreground(colors.Red()).
+				Render("1 task due today")
 		} else {
-			taskDueMessage = textStyleRed(fmt.Sprintf("%d tasks due today", numDueTasks))
+			taskDueMessage = lipgloss.NewStyle().
+				Foreground(colors.Red()).
+				Render(fmt.Sprintf("%d tasks due today", numDueTasks))
 		}
 	}
 
 	taskTotalCompleteMessage := fmt.Sprintf("%d/%d tasks completed", numCompletedTasks, numTasks)
 	if numCompletedTasks == numTasks {
-		taskTotalCompleteMessage = textStyleGreen(taskTotalCompleteMessage)
+		taskTotalCompleteMessage = lipgloss.NewStyle().Foreground(colors.Green()).Render(taskTotalCompleteMessage)
 	}
 
 	right := listItemInfoStyle.Render(
@@ -212,7 +217,10 @@ func InitialProjectListModel() ProjectListModel {
 	itemList.SetShowStatusBar(true)
 	itemList.SetStatusBarItemName("project", "projects")
 	itemList.Title = "Projects"
-	itemList.Styles.Title = titleStyleProjects
+	itemList.Styles.Title = lipgloss.NewStyle().
+		Foreground(colors.BadgeText()).
+		Background(colors.Green()).
+		Padding(0, 1)
 	// Disable the quit keybindings, so we can implement our own.
 	itemList.DisableQuitKeybindings()
 	// Set our own prev/next page keys.
@@ -453,13 +461,15 @@ func (m ProjectListModel) View() string {
 	// Display progress bar at 100%
 	if m.progressDone && m.waitingAfterDone {
 		return centeredStyle.Bold(true).
-			Render(textStyleGreen(m.status) + "\n\n" + m.progress.ViewAs(1.0))
+			Render(lipgloss.NewStyle().Foreground(colors.Green()).Render(m.status) +
+				"\n\n" + m.progress.ViewAs(1.0))
 	}
 
 	// Display progress bar if not at 0%
 	if m.progress.Percent() != 0.0 {
 		return centeredStyle.Bold(true).
-			Render(textStyleGreen(m.status) + "\n\n" + m.progress.View())
+			Render(lipgloss.NewStyle().Foreground(colors.Green()).Render(m.status) +
+				"\n\n" + m.progress.View())
 	}
 
 	// Display deletion confirm view.
@@ -468,7 +478,9 @@ func (m ProjectListModel) View() string {
 
 		return centeredStyle.Render(
 			fmt.Sprintf("Delete \"%s\"?\n\n", selected.Title) +
-				textStyleRed("[y] Yes") + "    " + textStyleGreen("[n] No"),
+				lipgloss.NewStyle().Foreground(colors.Red()).Render("[y] Yes") +
+				"    " +
+				lipgloss.NewStyle().Foreground(colors.Green()).Render("[n] No"),
 		)
 	}
 

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -363,8 +363,8 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.progress.SetPercent(0.10),
 						tickCmd(),
 						m.list.SelectedItem().(*items.Project).DeleteProjectFromFS(),
-						vcs.CommitCmd(m.list.SelectedItem().(*items.Project).ID,
-							"delete: "+m.list.SelectedItem().(*items.Project).Title),
+						vcs.CommitCmd("delete: "+m.list.SelectedItem().(*items.Project).Title,
+							m.list.SelectedItem().(*items.Project).ID),
 					)
 					m.status = ""
 				}

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -380,7 +380,7 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if idx := project.FindListIndexByID(m.list.Items()); idx >= 0 {
 				m.list.RemoveItem(idx)
 				delete(m.selectedItems, i)
-				m.status = "🗑  Project deleted"
+				m.status = "🗑  Project(s) deleted"
 
 				return m, m.progress.SetPercent(0.5)
 			}

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -143,7 +143,7 @@ func (d customProjectDelegate) Render(w io.Writer, m list.Model, index int, item
 	if selected {
 		marker = lipgloss.NewStyle().
 			Foreground(colors.Red()).
-			Render("⏺ ")
+			Render("⟹  ")
 	}
 
 	left := listItemStyle.Render(marker + projectItem.Title + "\n" +

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -50,6 +50,7 @@ type projectListKeyMap struct {
 	deleteProject  key.Binding
 	prevPage       key.Binding
 	nextPage       key.Binding
+	toggleSelect   key.Binding
 }
 
 // newProjectListKeyMap returns a new set of key
@@ -88,6 +89,10 @@ func newProjectListKeyMap() *projectListKeyMap {
 			key.WithKeys("right", "pgdown", "f", "d"),
 			key.WithHelp("→/pgdn/f/d", "next page"),
 		),
+		toggleSelect: key.NewBinding(
+			key.WithKeys(" "),
+			key.WithHelp("space", "toggle select"),
+		),
 	}
 }
 
@@ -95,6 +100,7 @@ func newProjectListKeyMap() *projectListKeyMap {
 // renderer for items in the project list.
 type customProjectDelegate struct {
 	list.DefaultDelegate
+	parent *ProjectListModel
 }
 
 // Render renders a custom project item in the list,
@@ -130,7 +136,17 @@ func (d customProjectDelegate) Render(w io.Writer, m list.Model, index int, item
 		listItemStyle = listItemStyle.MarginLeft(1)
 	}
 
-	left := listItemStyle.Render(projectItem.Title + "\n" +
+	// Check if item is selected
+	_, selected := d.parent.selectedItems[index]
+
+	marker := ""
+	if selected {
+		marker = lipgloss.NewStyle().
+			Foreground(colors.Red()).
+			Render("⏺ ")
+	}
+
+	left := listItemStyle.Render(marker + projectItem.Title + "\n" +
 		projectItem.Description)
 
 	numTasks, numCompletedTasks, numDueTasks, err := projectItem.NumOfTasks()
@@ -189,6 +205,7 @@ type ProjectListModel struct {
 	waitingAfterDone bool
 	status           string
 	width, height    int
+	selectedItems    map[int]*items.Project
 
 	renderer *glamour.TermRenderer
 }
@@ -206,9 +223,17 @@ func InitialProjectListModel() ProjectListModel {
 		listItems = append(listItems, &project)
 	}
 
+	selectedItems := make(map[int]*items.Project)
+
+	m := ProjectListModel{
+		keys:          listKeys,
+		progress:      progress.New(progress.WithGradient("#FFA336", "#02BF87")),
+		selectedItems: selectedItems,
+	}
+
 	itemList := list.New(
 		listItems,
-		customProjectDelegate{DefaultDelegate: list.NewDefaultDelegate()},
+		customProjectDelegate{DefaultDelegate: list.NewDefaultDelegate(), parent: &m},
 		0,
 		0,
 	)
@@ -216,6 +241,7 @@ func InitialProjectListModel() ProjectListModel {
 	itemList.SetShowTitle(true)
 	itemList.SetShowStatusBar(true)
 	itemList.SetStatusBarItemName("project", "projects")
+	itemList.StatusMessageLifetime = 3 * time.Second
 	itemList.Title = "Projects"
 	itemList.Styles.Title = lipgloss.NewStyle().
 		Foreground(colors.BadgeText()).
@@ -238,20 +264,20 @@ func InitialProjectListModel() ProjectListModel {
 			listKeys.addProject,
 			listKeys.editProject,
 			listKeys.deleteProject,
+			listKeys.toggleSelect,
 		}
 	}
+
+	m.list = itemList
 
 	renderer, err := glamour.NewTermRenderer(glamour.WithAutoStyle())
 	if err != nil {
 		panic(err)
 	}
 
-	return ProjectListModel{
-		list:     itemList,
-		keys:     listKeys,
-		renderer: renderer,
-		progress: progress.New(progress.WithGradient("#FFA336", "#02BF87")),
-	}
+	m.renderer = renderer
+
+	return m
 }
 
 // Init initializes the Bubble Tea program
@@ -303,6 +329,10 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case vcs.CommitDoneMsg:
+		// Remove all map entries after successful commit.
+		for k := range m.selectedItems {
+			delete(m.selectedItems, k)
+		}
 		m.status = "🗘  Changes committed"
 		m.progressDone = true
 		return m, m.progress.SetPercent(1.0)
@@ -346,9 +376,15 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.progress.SetPercent(0.0)
 
 	case items.ProjectDeleteDoneMsg:
-		m.list.RemoveItem(m.list.GlobalIndex())
-		m.status = "🗑  Project deleted"
-		return m, m.progress.SetPercent(0.5)
+		for i, project := range m.selectedItems {
+			if idx := project.FindListIndexByID(m.list.Items()); idx >= 0 {
+				m.list.RemoveItem(idx)
+				delete(m.selectedItems, i)
+				m.status = "🗑  Project deleted"
+
+				return m, m.progress.SetPercent(0.5)
+			}
+		}
 
 	case items.ProjectDeleteErrorMsg:
 		m.mode = 2
@@ -366,16 +402,26 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case modeConfirmDelete:
 			switch msg.String() {
 			case "y", "Y":
-				if m.list.SelectedItem() != nil {
-					cmds = append(cmds,
-						m.progress.SetPercent(0.10),
-						tickCmd(),
-						m.list.SelectedItem().(*items.Project).DeleteProjectFromFS(),
-						vcs.CommitCmd("delete: "+m.list.SelectedItem().(*items.Project).Title,
-							m.list.SelectedItem().(*items.Project).ID),
-					)
-					m.status = ""
+				if len(m.selectedItems) == 0 {
+
+					m.mode = modeNormal
+					return m, nil
 				}
+
+				var projectNames, projectPaths []string
+				var deleteCmds []tea.Cmd
+				for _, item := range m.selectedItems {
+					projectNames = append(projectNames, item.Title)
+					projectPaths = append(projectPaths, item.ID)
+					deleteCmds = append(deleteCmds, item.DeleteProjectFromFS())
+				}
+
+				message := fmt.Sprintf("delete: %d project(s)\n\n- %s", len(projectNames), strings.Join(projectNames, "\n- "))
+				cmds = append(cmds, m.progress.SetPercent(0.10), tickCmd())
+				cmds = append(cmds, deleteCmds...)
+				cmds = append(cmds, vcs.CommitCmd(message, projectPaths...))
+
+				m.status = ""
 
 				m.mode = modeNormal
 				return m, tea.Batch(cmds...)
@@ -416,10 +462,15 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 
 			case key.Matches(msg, m.keys.deleteProject):
-				if m.list.SelectedItem() != nil {
+				if len(m.selectedItems) > 0 {
 					m.mode = modeConfirmDelete
+				} else {
+					cmds = append(cmds, m.list.NewStatusMessage(lipgloss.NewStyle().
+						Foreground(colors.Red()).
+						Render("No project selected")))
 				}
-				return m, nil
+
+				return m, tea.Batch(cmds...)
 
 			case key.Matches(msg, m.keys.editProject):
 				if m.list.SelectedItem() != nil {
@@ -436,6 +487,19 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 				formModel := newProjectFormModel(project, &m, false)
 				return formModel, tea.WindowSize()
+
+			case key.Matches(msg, m.keys.toggleSelect):
+				if m.list.SelectedItem() != nil {
+					p := m.list.SelectedItem().(*items.Project)
+					i := m.list.GlobalIndex()
+
+					if _, ok := m.selectedItems[i]; ok {
+						delete(m.selectedItems, i)
+					} else {
+						m.selectedItems[i] = p
+					}
+					return m, nil
+				}
 			}
 		default:
 			panic("unhandled default case in project list")
@@ -474,14 +538,14 @@ func (m ProjectListModel) View() string {
 
 	// Display deletion confirm view.
 	if m.mode == modeConfirmDelete {
-		selected := m.list.SelectedItem().(*items.Project)
-
-		return centeredStyle.Render(
-			fmt.Sprintf("Delete \"%s\"?\n\n", selected.Title) +
-				lipgloss.NewStyle().Foreground(colors.Red()).Render("[y] Yes") +
-				"    " +
-				lipgloss.NewStyle().Foreground(colors.Green()).Render("[n] No"),
-		)
+		if len(m.selectedItems) > 0 {
+			return centeredStyle.Render(
+				fmt.Sprintf("Delete %d project(s)?\n\n", len(m.selectedItems)) +
+					lipgloss.NewStyle().Foreground(colors.Red()).Render("[y] Yes") +
+					"    " +
+					lipgloss.NewStyle().Foreground(colors.Green()).Render("[n] No"),
+			)
+		}
 	}
 
 	// Display VCS error view

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -287,8 +287,8 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				tickCmd(),
 				m.task.WriteTaskJSON(json, *m.listModel.project, action),
 				vcs.CommitCmd(
-					taskPath,
 					fmt.Sprintf("%s: %s", action, m.task.Title),
+					taskPath,
 				),
 			)
 

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -433,10 +433,10 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.progress.SetPercent(0.0)
 
 	case items.TaskDeleteDoneMsg:
-		for key, task := range m.selected {
-			if index := task.FindListIndexByID(m.list.Items()); index >= 0 {
-				m.list.RemoveItem(index)
-				delete(m.selected, key)
+		for i, task := range m.selected {
+			if idx := task.FindListIndexByID(m.list.Items()); idx >= 0 {
+				m.list.RemoveItem(idx)
+				delete(m.selected, i)
 				m.status = "🗑  Task deleted"
 
 				return m, m.progress.SetPercent(0.5)

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -191,7 +191,7 @@ func (d customTaskDelegate) Render(w io.Writer, m list.Model, index int, item li
 	if selected {
 		marker = lipgloss.NewStyle().
 			Foreground(colors.Red()).
-			Render("⏺ ")
+			Render("⟹  ")
 	}
 
 	left := titleStyle.Render(marker+taskItem.CropTaskTitle(taskEntryLength)) + "\n" +

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -310,6 +310,7 @@ func newTaskListModel(project *items.Project, projectModel *ProjectListModel) ta
 	itemList.SetShowTitle(true)
 	itemList.SetShowStatusBar(true)
 	itemList.SetStatusBarItemName("task", "tasks")
+	itemList.StatusMessageLifetime = 3 * time.Second
 	itemList.Title = project.Title
 	itemList.Styles.Title = titleStyleTasks
 	// Disable the quit keybindings, so we can implement our own.
@@ -379,6 +380,10 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.progress.SetPercent(0.0)
 
 	case vcs.CommitDoneMsg:
+		// Remove all map entries after successful commit.
+		for k := range m.selected {
+			delete(m.selected, k)
+		}
 		m.status = "🗘  Changes committed"
 		m.progressDone = true
 		return m, m.progress.SetPercent(1.0)
@@ -443,13 +448,6 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
-		selected := m.list.SelectedItem()
-		if selected != nil {
-			m.list.RemoveItem(m.list.Index())
-		}
-		m.status = "🗑  Task deleted"
-		return m, m.progress.SetPercent(0.5)
-
 	case items.TaskDeleteErrorMsg:
 		m.mode = 2
 		m.err = msg.Err
@@ -466,37 +464,26 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case modeConfirmDelete:
 			switch msg.String() {
 			case "y", "Y":
-				if len(m.selected) > 0 {
-					var taskNames, taskPaths []string
-					var deleteCmds []tea.Cmd
-					for _, item := range m.selected {
-						taskNames = append(taskNames, item.Title)
-						taskPaths = append(taskPaths, filepath.Join(m.project.ID, item.ID+".json"))
-						deleteCmds = append(deleteCmds, item.DeleteTaskFromFS(*m.project))
-					}
+				if len(m.selected) == 0 {
 
-					message := fmt.Sprintf("delete: %d task(s)\n\n- %s", len(taskNames), strings.Join(taskNames, "\n- "))
-					cmds = append(cmds, m.progress.SetPercent(0.10), tickCmd())
-					cmds = append(cmds, deleteCmds...)
-					cmds = append(cmds, vcs.CommitCmd(message, taskPaths...))
-
-					m.status = ""
 					m.mode = modeNormal
-					return m, tea.Batch(cmds...)
+					return m, nil
 				}
 
-				if m.list.SelectedItem() != nil {
-					cmds = append(cmds,
-						m.progress.SetPercent(0.10),
-						tickCmd(),
-						m.list.SelectedItem().(*items.Task).DeleteTaskFromFS(*m.project),
-						vcs.CommitCmd("delete: "+m.list.SelectedItem().(*items.Task).Title,
-							filepath.Join(m.project.ID, m.list.SelectedItem().(*items.Task).ID+".json"),
-						),
-					)
-					m.status = ""
+				var taskNames, taskPaths []string
+				var deleteCmds []tea.Cmd
+				for _, item := range m.selected {
+					taskNames = append(taskNames, item.Title)
+					taskPaths = append(taskPaths, filepath.Join(m.project.ID, item.ID+".json"))
+					deleteCmds = append(deleteCmds, item.DeleteTaskFromFS(*m.project))
 				}
 
+				message := fmt.Sprintf("delete: %d task(s)\n\n- %s", len(taskNames), strings.Join(taskNames, "\n- "))
+				cmds = append(cmds, m.progress.SetPercent(0.10), tickCmd())
+				cmds = append(cmds, deleteCmds...)
+				cmds = append(cmds, vcs.CommitCmd(message, taskPaths...))
+
+				m.status = ""
 				m.mode = modeNormal
 				return m, tea.Batch(cmds...)
 
@@ -544,71 +531,50 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 
 			case key.Matches(msg, m.keys.toggleInProgress):
-				if m.list.SelectedItem() != nil {
-					t := m.list.SelectedItem().(*items.Task)
+				m, cmds := m.toggleTasks(
+					func(t *items.Task) { t.InProgress = !t.InProgress },
+					func(t *items.Task) (bool, string) {
+						if t.Completed {
+							return false, "Cannot set done task as in progress"
+						}
+						return true, ""
+					},
+					func(t *items.Task) string {
+						if t.InProgress {
+							return "stop"
+						}
+						return "start"
+					},
+					"progress",
+				)
 
-					if t.Completed {
-						return m, m.list.NewStatusMessage(textStyleRed("Cannot set done task in progress"))
-					}
-
-					t.InProgress = !t.InProgress
-					json := t.MarshalTask()
-
-					cmds = append(cmds, tickCmd(), m.progress.SetPercent(0.10))
-					if t.InProgress {
-						cmds = append(cmds,
-							t.WriteTaskJSON(json, *m.project, "start"),
-							vcs.CommitCmd("starting progress: "+t.Title,
-								filepath.Join(m.project.ID, t.ID+".json")),
-						)
-						m.status = ""
-						return m, tea.Batch(cmds...)
-					}
-
-					cmds = append(cmds,
-						t.WriteTaskJSON(json, *m.project, "stop"),
-						vcs.CommitCmd("stopping progress: "+t.Title,
-							filepath.Join(m.project.ID, t.ID+".json")),
-					)
-					m.status = ""
-					return m, tea.Batch(cmds...)
-				}
-				return m, nil
+				return m, tea.Batch(cmds...)
 
 			case key.Matches(msg, m.keys.toggleComplete):
-				if m.list.SelectedItem() != nil {
-					t := m.list.SelectedItem().(*items.Task)
-					t.InProgress = false
-					t.Completed = !t.Completed
+				m, cmds := m.toggleTasks(
+					func(t *items.Task) { t.Completed = !t.Completed; t.InProgress = false },
+					func(_ *items.Task) (bool, string) { return true, "" },
+					func(t *items.Task) string {
+						if t.Completed {
+							return "complete"
+						}
+						return "reopen"
+					},
+					"completion",
+				)
 
-					json := t.MarshalTask()
-
-					cmds = append(cmds, tickCmd(), m.progress.SetPercent(0.10))
-					if t.Completed {
-						cmds = append(cmds,
-							t.WriteTaskJSON(json, *m.project, "complete"),
-							vcs.CommitCmd("complete: "+t.Title,
-								filepath.Join(m.project.ID, t.ID+".json")),
-						)
-						m.status = ""
-						return m, tea.Batch(cmds...)
-					}
-
-					cmds = append(cmds,
-						t.WriteTaskJSON(json, *m.project, "reopen"),
-						vcs.CommitCmd("reopen: "+t.Title,
-							filepath.Join(m.project.ID, t.ID+".json")),
-					)
-					m.status = ""
-					return m, tea.Batch(cmds...)
-				}
-				return m, nil
+				return m, tea.Batch(cmds...)
 
 			case key.Matches(msg, m.keys.deleteItem):
-				if m.list.SelectedItem() != nil {
+				if len(m.selected) > 0 {
 					m.mode = modeConfirmDelete
+				} else {
+					cmds = append(cmds, m.list.NewStatusMessage(lipgloss.NewStyle().
+						Foreground(colors.Red()).
+						Render("No task selected")))
 				}
-				return m, nil
+
+				return m, tea.Batch(cmds...)
 
 			case key.Matches(msg, m.keys.editItem):
 				if m.list.SelectedItem() != nil {
@@ -664,13 +630,15 @@ func (m taskListModel) View() string {
 	// Display progress bar at 100%
 	if m.progressDone && m.waitingAfterDone {
 		return centeredStyle.Bold(true).
-			Render(textStyleGreen(m.status) + "\n\n" + m.progress.ViewAs(1.0))
+			Render(lipgloss.NewStyle().Foreground(colors.Green()).Render(m.status) +
+				"\n\n" + m.progress.ViewAs(1.0))
 	}
 
 	// Display progress bar if not at 0%
 	if m.progress.Percent() != 0.0 {
 		return centeredStyle.Bold(true).
-			Render(textStyleGreen(m.status) + "\n\n" + m.progress.View())
+			Render(lipgloss.NewStyle().Foreground(colors.Green()).Render(m.status) +
+				"\n\n" + m.progress.View())
 	}
 
 	// Display deletion confirm view.
@@ -679,7 +647,9 @@ func (m taskListModel) View() string {
 		if len(m.selected) > 0 {
 			return centeredStyle.Render(
 				fmt.Sprintf("Delete %d task(s)?\n\n", len(m.selected)) +
-					textStyleRed("[y] Yes") + "    " + textStyleGreen("[n] No"),
+					lipgloss.NewStyle().Foreground(colors.Red()).Render("[y] Yes") +
+					"    " +
+					lipgloss.NewStyle().Foreground(colors.Green()).Render("[n] No"),
 			)
 		}
 
@@ -687,7 +657,9 @@ func (m taskListModel) View() string {
 
 		return centeredStyle.Render(
 			fmt.Sprintf("Delete \"%s\"?\n\n", selected.Title) +
-				textStyleRed("[y] Yes") + "    " + textStyleGreen("[n] No"),
+				lipgloss.NewStyle().Foreground(colors.Red()).Render("[y] Yes") +
+				"    " +
+				lipgloss.NewStyle().Foreground(colors.Green()).Render("[n] No"),
 		)
 	}
 
@@ -789,4 +761,63 @@ func sortTasksByKeys(m *list.Model, keys []string) {
 			}
 		}
 	}
+}
+
+// toggleTasks applies a toggle operation to all selected tasks in the task list.
+//
+// Parameters:
+//   - toggleFunc: a function that modifies a task (e.g., toggling InProgress or Completed).
+//   - precondition: a function that checks whether the task can be toggled; returns
+//     a bool indicating if the task passes the check, and a string message if not.
+//   - commitKind: a function that determines the kind of action for the task (used
+//     in writing JSON and commit messages).
+//   - actionName: a string describing the type of action (e.g., "progress" or "completion")
+//     used in the commit message.
+//
+// The function returns an updated taskListModel and a slice of tea.Cmds that perform
+// the necessary operations, including writing JSON, updating progress, and creating
+// a VCS commit. If no tasks are selected, it returns a status message and no other
+// operations.
+func (m taskListModel) toggleTasks(
+	toggleFunc func(*items.Task),
+	precondition func(*items.Task) (bool, string),
+	commitKind func(*items.Task) string,
+	actionName string,
+) (taskListModel, []tea.Cmd) {
+	if len(m.selected) == 0 {
+		return m, []tea.Cmd{
+			m.list.NewStatusMessage(lipgloss.NewStyle().
+				Foreground(colors.Red()).
+				Render("No task selected")),
+		}
+	}
+
+	var cmds, writeCmds []tea.Cmd
+	var taskPaths, taskNames []string
+
+	for _, t := range m.selected {
+		ok, msg := precondition(t)
+		if !ok {
+			cmds = append(cmds, m.list.NewStatusMessage(lipgloss.NewStyle().
+				Foreground(colors.Red()).
+				Render(msg)))
+
+			return m, cmds
+		}
+
+		toggleFunc(t)
+		json := t.MarshalTask()
+		writeCmds = append(writeCmds, t.WriteTaskJSON(json, *m.project, commitKind(t)))
+		taskPaths = append(taskPaths, filepath.Join(m.project.ID, t.ID+".json"))
+		taskNames = append(taskNames, t.Title)
+	}
+
+	commitMsg := fmt.Sprintf("Change %s state of %d task(s)\n\n- %s",
+		actionName, len(taskNames), strings.Join(taskNames, "\n- "))
+
+	cmds = append(cmds, tickCmd(), m.progress.SetPercent(0.10))
+	cmds = append(cmds, writeCmds...)
+	cmds = append(cmds, vcs.CommitCmd(commitMsg, taskPaths...))
+
+	return m, cmds
 }

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -70,11 +70,11 @@ func newTaskListKeyMap() *taskListKeyMap {
 		),
 		toggleComplete: key.NewBinding(
 			key.WithKeys("C"),
-			key.WithHelp("C", "toggle complete"),
+			key.WithHelp("C", "toggle complete on selection"),
 		),
 		toggleInProgress: key.NewBinding(
 			key.WithKeys("P"),
-			key.WithHelp("P", "toggle in progress"),
+			key.WithHelp("P", "toggle in progress on selection"),
 		),
 		sortByPriority: key.NewBinding(
 			key.WithKeys("alt+p"),
@@ -86,19 +86,19 @@ func newTaskListKeyMap() *taskListKeyMap {
 		),
 		deleteItem: key.NewBinding(
 			key.WithKeys("D"),
-			key.WithHelp("D", "delete"),
+			key.WithHelp("D", "delete selected tasks"),
 		),
 		editItem: key.NewBinding(
 			key.WithKeys("e"),
-			key.WithHelp("e", "edit"),
+			key.WithHelp("e", "edit task"),
 		),
 		chooseItem: key.NewBinding(
 			key.WithKeys("enter", "l"),
-			key.WithHelp("enter/l", "show"),
+			key.WithHelp("enter/l", "show task"),
 		),
 		addItem: key.NewBinding(
 			key.WithKeys("a"),
-			key.WithHelp("a", "add item"),
+			key.WithHelp("a", "add task"),
 		),
 		toggleHelpMenu: key.NewBinding(
 			key.WithKeys("H"),
@@ -118,7 +118,7 @@ func newTaskListKeyMap() *taskListKeyMap {
 		),
 		toggleSelect: key.NewBinding(
 			key.WithKeys(" "),
-			key.WithHelp("space", "toggle select"),
+			key.WithHelp("space", "select/deselect"),
 		),
 	}
 }
@@ -646,11 +646,11 @@ func (m taskListModel) View() string {
 		// Check bulk selection
 		if len(m.selectedItems) > 0 {
 			return centeredStyle.Render(
-				fmt.Sprintf("Delete %d task(s)?\n\n", len(m.selectedItems)) +
-					lipgloss.NewStyle().Foreground(colors.Red()).Render("[y] Yes") +
-					"    " +
-					lipgloss.NewStyle().Foreground(colors.Green()).Render("[n] No"),
-			)
+				fmt.Sprintf("Delete %d task(s)?\n\n%s%s%s", len(m.selectedItems),
+					"[y] Yes",
+					"    ",
+					"[n] No",
+				))
 		}
 	}
 

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -531,7 +531,7 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, nil
 
 			case key.Matches(msg, m.keys.toggleInProgress):
-				m, cmds := m.toggleTasks(
+				m, cmds = m.toggleTasks(
 					func(t *items.Task) { t.InProgress = !t.InProgress },
 					func(t *items.Task) (bool, string) {
 						if t.Completed {
@@ -551,7 +551,7 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				return m, tea.Batch(cmds...)
 
 			case key.Matches(msg, m.keys.toggleComplete):
-				m, cmds := m.toggleTasks(
+				m, cmds = m.toggleTasks(
 					func(t *items.Task) { t.Completed = !t.Completed; t.InProgress = false },
 					func(_ *items.Task) (bool, string) { return true, "" },
 					func(t *items.Task) string {

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -416,16 +416,16 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = "🗸  Task updated"
 
 		case "start":
-			m.status = "🗸  Task started"
+			m.status = "🗸  Task(s) started"
 
 		case "stop":
-			m.status = "🗸  Task stopped"
+			m.status = "🗸  Task(s) stopped"
 
 		case "complete":
-			m.status = "🗸  Task completed"
+			m.status = "🗸  Task(s) completed"
 
 		case "reopen":
-			m.status = "🗸  Task reopened"
+			m.status = "🗸  Task(s) reopened"
 
 		default:
 			return m, nil
@@ -442,7 +442,7 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if idx := task.FindListIndexByID(m.list.Items()); idx >= 0 {
 				m.list.RemoveItem(idx)
 				delete(m.selectedItems, i)
-				m.status = "🗑  Task deleted"
+				m.status = "🗑  Task(s) deleted"
 
 				return m, m.progress.SetPercent(0.5)
 			}
@@ -541,9 +541,9 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					},
 					func(t *items.Task) string {
 						if t.InProgress {
-							return "stop"
+							return "start"
 						}
-						return "start"
+						return "stop"
 					},
 					"progress",
 				)

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -74,9 +74,9 @@ func gitInitCmd() tea.Cmd {
 // gitCommitCmd stages and commits the specified file with the given message.
 // If Git remote support is enabled, it pulls from the remote before committing.
 // Returns a CommitDoneMsg or CommitErrorMsg.
-func gitCommitCmd(file, message string) tea.Cmd {
+func gitCommitCmd(message string, files ...string) tea.Cmd {
 	return func() tea.Msg {
-		if output, err := gitCommit(file, message); err != nil {
+		if output, err := gitCommit(message, files...); err != nil {
 			return CommitErrorMsg{string(output), err}
 		}
 
@@ -130,11 +130,10 @@ func gitPull() ([]byte, error) {
 // If there are no changes, it returns nil. If remote is enabled,
 // it pushes the commit to the configured remote and branch.
 // Returns an error if any Git command fails.
-func gitCommit(file, message string) ([]byte, error) {
-	addCmd := exec.Command("git",
-		"add",
-		file,
-	)
+func gitCommit(message string, files ...string) ([]byte, error) {
+	args := append([]string{"add"}, files...)
+
+	addCmd := exec.Command("git", args...)
 	addCmd.Dir = viper.GetString("storage.path")
 	output, err := addCmd.CombinedOutput()
 	if err != nil {

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -71,8 +71,8 @@ func gitInitCmd() tea.Cmd {
 	}
 }
 
-// gitCommitCmd stages and commits the specified file with the given message.
-// If Git remote support is enabled, it pulls from the remote before committing.
+// gitCommitCmd stages and commits the specified files with the given message.
+// If Git remote support is enabled, it pulls from the remote and rebases before pushing.
 // Returns a CommitDoneMsg or CommitErrorMsg.
 func gitCommitCmd(message string, files ...string) tea.Cmd {
 	return func() tea.Msg {
@@ -126,7 +126,7 @@ func gitPull() ([]byte, error) {
 	return output, nil
 }
 
-// gitCommit stages the specified file and commits it with the given message.
+// gitCommit stages the specified files and commits them with the given message.
 // If there are no changes, it returns nil. If remote is enabled,
 // it pushes the commit to the configured remote and branch.
 // Returns an error if any Git command fails.

--- a/internal/vcs/git.go
+++ b/internal/vcs/git.go
@@ -140,13 +140,14 @@ func gitCommit(message string, files ...string) ([]byte, error) {
 		return output, err
 	}
 
-	if err := exec.Command("git",
+	diffCmd := exec.Command("git",
 		"diff",
 		"--cached",
-		"--quiet",
-	).Run(); err == nil {
-		// Exit code 0 = no staged changes
-		return []byte{}, nil // Already committed.
+	)
+	diffCmd.Dir = viper.GetString("storage.path")
+	output, _ = diffCmd.CombinedOutput()
+	if len(output) == 0 {
+		return output, nil
 	}
 
 	commitCmd := exec.Command("git",
@@ -154,7 +155,7 @@ func gitCommit(message string, files ...string) ([]byte, error) {
 		"--message",
 		message,
 	)
-	addCmd.Dir = viper.GetString("storage.path")
+	commitCmd.Dir = viper.GetString("storage.path")
 	output, err = commitCmd.CombinedOutput()
 	if err != nil {
 		return output, err

--- a/internal/vcs/resolver.go
+++ b/internal/vcs/resolver.go
@@ -43,10 +43,10 @@ func InitCmd() tea.Cmd {
 
 // CommitCmd returns the backend specific commit command according
 // to configuration.
-func CommitCmd(file, message string) tea.Cmd {
+func CommitCmd(message string, files ...string) tea.Cmd {
 	switch viper.GetString("vcs.backend") {
 	case "git":
-		return gitCommitCmd(file, message)
+		return gitCommitCmd(message, files...)
 	case "jj":
 		return jjCommitCmd(message)
 	default:


### PR DESCRIPTION
## Type of Change

- [x] New feature (non-breaking change)

## Description

This is a PR with quite a lot of code change. It allows to select n tasks from the list and run our already known actions against it. That is:

- delete all selected tasks
- toggle completion state
- toggle progress state

Each bulk action triggers one commit only.

## Some things to be aware of:

- the toggle commands still work the same. That means if you select one open and one done task and toggle completion state, both tasks will just toggle. I'm not convinced about this, I think that's bad UX. We should probably replace the toggle command with a setDone/setOpen and likewise a setInProgress/setHalt command. 
-  right know you cannot run the commands against a list item that is not selected. Even for a single change you have to select the item first (a warning message is shown if no item is selected). That's probably something to argue about, because it does add a keystroke to quick changes. However, it does also make accidental changes less likely.

## Next steps

- I'd like to implement the selection in the project list as well.

(resolves #24)
(fixes #14)
