### PR TITLE
feat: task encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,17 +22,16 @@ and manages your task directory as a Git or Jujutsu repository.
     - collaboration via shared repositories
 - Automatic commit on every change (optional auto-push)
 - Project-based task organization
+- Full-text search
 - Task attributes with sorting support:
     - due dates
     - status (open, in-progress, done)
     - priority
     - author / assignee
-- Task attributes with filtering support:
-    - titles
-    - labels
 - Markdown support for task descriptions
 - Non-interactive output (`yatto print`) for simple dashboards
 - Simple theme and color customization
+- Optional task encryption
 
 ## Requirements
 
@@ -204,6 +203,37 @@ See [examples/config.toml](examples/config.toml) as a reference with all availab
 > ```bash
 > yatto --config $PATH_TO_CONFIG_FILE
 > ```
+
+### Encryption
+
+yatto supports encrypting your task and project files at rest using AES-256-GCM.
+
+To enable encryption:
+
+1. Generate a new encryption key:
+
+    ```bash
+    yatto key generate
+    ```
+
+    This creates a key file at `~/.config/yatto/encryption.key` by default.
+    Use `--output` to specify a different path and `--force` to overwrite an existing key.
+
+2. Update your config file:
+    ```toml
+    [encryption]
+    enable = true
+    key_path = "~/.config/yatto/encryption.key"
+    ```
+
+> [!WARNING]
+> When encryption is enabled:
+>
+> - Task files are stored as **base64-encoded encrypted text** (git-friendly)
+> - `git diff/show` will show changes in the base64 encoding (not meaningful content)
+> - You cannot read or edit task files directly with a text editor (they are encrypted)
+> - Git history will only show encrypted content, making it impossible to recover old versions of tasks
+> - **Keep your key safe!** Losing the key means losing access to all your encrypted tasks.
 
 ### Colors and themes
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ and manages your task directory as a Git or Jujutsu repository.
 - Markdown support for task descriptions
 - Non-interactive output (`yatto print`) for simple dashboards
 - Simple theme and color customization
-- Optional task encryption
+- Optional task encryption (experimental)
 
 ## Requirements
 

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	keyOutputPath string
+	keyForce      bool
 )
 
 // keyCmd represents the key command
@@ -75,6 +76,15 @@ Then update your config.toml:
 			}
 		}
 
+		// Check if key file already exists
+		if _, err := os.Stat(keyOutputPath); err == nil {
+			if !keyForce {
+				return fmt.Errorf("key file already exists at %s. Use --force to overwrite, or remove the existing file first", keyOutputPath)
+			}
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to check key file: %w", err)
+		}
+
 		// Ensure parent directory exists
 		if err := os.MkdirAll(filepath.Dir(keyOutputPath), 0o700); err != nil {
 			return fmt.Errorf("failed to create directory: %w", err)
@@ -103,4 +113,6 @@ func init() {
 
 	keyGenerateCmd.Flags().StringVarP(&keyOutputPath, "output", "o", "",
 		"Output path for the encryption key file (default: ~/.config/yatto/encryption.key)")
+	keyGenerateCmd.Flags().BoolVarP(&keyForce, "force", "f", false,
+		"Overwrite existing key file if it exists")
 }

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -1,0 +1,106 @@
+// Copyright 2025-2026 handlebargh and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/handlebargh/yatto/internal/encryption"
+	"github.com/spf13/cobra"
+)
+
+var (
+	keyOutputPath string
+)
+
+// keyCmd represents the key command
+var keyCmd = &cobra.Command{
+	Use:   "key",
+	Short: "Manage encryption keys",
+}
+
+// keyGenerateCmd generates a new encryption key
+var keyGenerateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate a new AES-256 encryption key",
+	Long: `Generate a new 32-byte AES-256 encryption key and save it to a file.
+
+The key is base64-encoded for easy storage. Keep this file secure!
+
+Example usage:
+  yatto key generate --output ~/.config/yatto/encryption.key
+
+Then update your config.toml:
+  [encryption]
+  enable = true
+  key_path = "/home/<you>/.config/yatto/encryption.key"
+`,
+	RunE: func(_ *cobra.Command, _ []string) error {
+		key, err := encryption.GenerateKey()
+		if err != nil {
+			return fmt.Errorf("failed to generate key: %w", err)
+		}
+
+		// Default output path if not specified
+		if keyOutputPath == "" {
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("failed to get home directory: %w", err)
+			}
+			keyOutputPath = filepath.Join(home, ".config", "yatto", "encryption.key")
+
+			// Create directory if it doesn't exist
+			if err := os.MkdirAll(filepath.Dir(keyOutputPath), 0o700); err != nil {
+				return fmt.Errorf("failed to create config directory: %w", err)
+			}
+		}
+
+		// Ensure parent directory exists
+		if err := os.MkdirAll(filepath.Dir(keyOutputPath), 0o700); err != nil {
+			return fmt.Errorf("failed to create directory: %w", err)
+		}
+
+		// Write key file with restrictive permissions
+		if err := os.WriteFile(keyOutputPath, []byte(key), 0o600); err != nil {
+			return fmt.Errorf("failed to write key file: %w", err)
+		}
+
+		fmt.Printf("Encryption key generated and saved to: %s\n", keyOutputPath)
+		fmt.Printf("\nIMPORTANT: Keep this file secure! Anyone with access to this key can decrypt your tasks.\n")
+		fmt.Printf("\nNext steps:\n")
+		fmt.Printf("1. Update your config.toml:\n")
+		fmt.Printf("   [encryption]\n")
+		fmt.Printf("   enable = true\n")
+		fmt.Printf("   key_path = \"%s\"\n", keyOutputPath)
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(keyCmd)
+	keyCmd.AddCommand(keyGenerateCmd)
+
+	keyGenerateCmd.Flags().StringVarP(&keyOutputPath, "output", "o", "",
+		"Output path for the encryption key file (default: ~/.config/yatto/encryption.key)")
+}

--- a/cmd/key.go
+++ b/cmd/key.go
@@ -79,7 +79,10 @@ Then update your config.toml:
 		// Check if key file already exists
 		if _, err := os.Stat(keyOutputPath); err == nil {
 			if !keyForce {
-				return fmt.Errorf("key file already exists at %s. Use --force to overwrite, or remove the existing file first", keyOutputPath)
+				return fmt.Errorf(
+					"key file already exists at %s. Use --force to overwrite, or remove the existing file first",
+					keyOutputPath,
+				)
 			}
 		} else if !os.IsNotExist(err) {
 			return fmt.Errorf("failed to check key file: %w", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,5 +141,6 @@ var encryptionKeyPath string
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Path to the config file")
-	rootCmd.PersistentFlags().StringVar(&encryptionKeyPath, "encryption-key", "", "Path to encryption key file (overrides config)")
+	rootCmd.PersistentFlags().
+		StringVar(&encryptionKeyPath, "encryption-key", "", "Path to encryption key file (overrides config)")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -126,12 +126,20 @@ func Execute() {
 
 	config.InitConfig(appConfig.Viper, homePath, &configPath)
 
+	// Set encryption key path from flag if provided (overrides config file)
+	if encryptionKeyPath != "" {
+		appConfig.Viper.Set("encryption.key_path", encryptionKeyPath)
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 }
 
+var encryptionKeyPath string
+
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&configPath, "config", "c", "", "Path to the config file")
+	rootCmd.PersistentFlags().StringVar(&encryptionKeyPath, "encryption-key", "", "Path to encryption key file (overrides config)")
 }

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -89,3 +89,14 @@ url = "git@github.com:<username>/<repo>.git"
 ## Replace with your actual home directory
 ## or any other path you'd like to use.
 path = "/home/<me>/.yatto"
+
+[encryption]
+## Enable encryption of task and project files at rest.
+## When enabled, all task and project JSON files will be encrypted
+## using AES-256-GCM with the key specified in key_path.
+enable = false
+
+## Path to the file containing the 32-byte encryption key (base64 encoded).
+## The key can be generated using: yatto key generate
+## Example: key_path = "/home/<me>/.config/yatto/encryption.key"
+key_path = ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,8 @@ type config struct {
 	jjRemoteName        string
 	colorsFormTheme     string
 	colorValues         map[string]string
+	encryptionEnable    bool
+	encryptionKeyPath   string
 }
 
 // InitConfig sets default values for application configuration and
@@ -114,6 +116,10 @@ func InitConfig(v *viper.Viper, home string, configPath *string) {
 
 	// Form themes
 	v.SetDefault("colors.form.theme", "Base16")
+
+	// Encryption
+	v.SetDefault("encryption.enable", false)
+	v.SetDefault("encryption.key_path", "")
 
 	if *configPath != "" {
 		v.SetConfigFile(*configPath)
@@ -285,6 +291,8 @@ func LoadAndValidateConfig(v *viper.Viper) error {
 		jjDefaultBranch:     v.GetString("jj.default_branch"),
 		jjRemoteName:        v.GetString("jj.remote.name"),
 		colorsFormTheme:     v.GetString("colors.form.theme"),
+		encryptionEnable:    v.GetBool("encryption.enable"),
+		encryptionKeyPath:   v.GetString("encryption.key_path"),
 		colorValues: map[string]string{
 			"colors.red_light":        v.GetString("colors.red_light"),
 			"colors.red_dark":         v.GetString("colors.red_dark"),
@@ -365,6 +373,16 @@ func (c *config) Validate() error {
 	for k, v := range c.colorValues {
 		if !colorRegexp.MatchString(v) {
 			return fmt.Errorf("invalid color value for '%s': %q", k, v)
+		}
+	}
+
+	// Encryption validation
+	if c.encryptionEnable {
+		if c.encryptionKeyPath == "" {
+			return fmt.Errorf("encryption is enabled but encryption.key_path is not set")
+		}
+		if !filepath.IsAbs(c.encryptionKeyPath) {
+			return fmt.Errorf("encryption.key_path must be absolute: %q", c.encryptionKeyPath)
 		}
 	}
 

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -1,0 +1,222 @@
+// Copyright 2025-2026 handlebargh and contributors
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Package encryption provides AES-256-GCM encryption and decryption utilities
+// for securing task and project data at rest.
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"io"
+	"os"
+)
+
+const (
+	// KeySize is the size in bytes for AES-256 keys.
+	KeySize = 32
+	// NonceSize is the size in bytes for GCM nonces.
+	NonceSize = 12
+	// TagSize is the size in bytes for GCM authentication tags.
+	TagSize = 16
+	// EncryptedFilePrefix is prepended to encrypted file content for identification.
+	EncryptedFilePrefix = "YATTO_ENC"
+)
+
+var (
+	// ErrInvalidKey is returned when the encryption key is not 32 bytes.
+	ErrInvalidKey = errors.New("encryption key must be 32 bytes for AES-256")
+	// ErrDecryptionFailed is returned when decryption fails (wrong key or corrupted data).
+	ErrDecryptionFailed = errors.New("decryption failed: invalid ciphertext or key")
+	// ErrNotEncrypted is returned when trying to decrypt data that is not encrypted.
+	ErrNotEncrypted = errors.New("data is not encrypted")
+)
+
+// Encrypt encrypts plaintext data using AES-256-GCM with the provided key.
+// Returns the encrypted ciphertext (nonce + ciphertext + tag) or an error.
+func Encrypt(plaintext, key []byte) ([]byte, error) {
+	if len(key) != KeySize {
+		return nil, ErrInvalidKey
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, NonceSize)
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nonce, nonce, plaintext, nil)
+
+	// Prepend our prefix for identification
+	result := make([]byte, len(EncryptedFilePrefix)+len(ciphertext))
+	copy(result, EncryptedFilePrefix)
+	copy(result[len(EncryptedFilePrefix):], ciphertext)
+
+	return result, nil
+}
+
+// Decrypt decrypts ciphertext data using AES-256-GCM with the provided key.
+// The ciphertext should have been produced by Encrypt() and includes the nonce.
+// Returns the decrypted plaintext or an error.
+func Decrypt(ciphertext, key []byte) ([]byte, error) {
+	if len(key) != KeySize {
+		return nil, ErrInvalidKey
+	}
+
+	// Check for encryption prefix
+	if len(ciphertext) < len(EncryptedFilePrefix) ||
+		string(ciphertext[:len(EncryptedFilePrefix)]) != EncryptedFilePrefix {
+		return nil, ErrNotEncrypted
+	}
+
+	actualCiphertext := ciphertext[len(EncryptedFilePrefix):]
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+	if len(actualCiphertext) < nonceSize {
+		return nil, ErrDecryptionFailed
+	}
+
+	nonce, ciphertextBytes := actualCiphertext[:nonceSize], actualCiphertext[nonceSize:]
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertextBytes, nil)
+	if err != nil {
+		return nil, ErrDecryptionFailed
+	}
+
+	return plaintext, nil
+}
+
+// IsEncrypted checks if the given data has the encryption prefix.
+func IsEncrypted(data []byte) bool {
+	return len(data) >= len(EncryptedFilePrefix) &&
+		string(data[:len(EncryptedFilePrefix)]) == EncryptedFilePrefix
+}
+
+// GenerateKey generates a new random 32-byte key suitable for AES-256.
+// The key is returned as a base64-encoded string for easy storage.
+func GenerateKey() (string, error) {
+	key := make([]byte, KeySize)
+	if _, err := rand.Read(key); err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(key), nil
+}
+
+// KeyFromBase64 decodes a base64-encoded key string into a byte slice.
+// Returns an error if the key is not valid base64 or not 32 bytes.
+func KeyFromBase64(base64Key string) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(base64Key)
+	if err != nil {
+		return nil, err
+	}
+	if len(key) != KeySize {
+		return nil, ErrInvalidKey
+	}
+	return key, nil
+}
+
+// EncryptFile encrypts a file's contents in place.
+// Reads from the given path, encrypts the data, and writes it back.
+func EncryptFile(path string, key []byte) error {
+	data, err := osReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Skip if already encrypted
+	if IsEncrypted(data) {
+		return nil
+	}
+
+	encrypted, err := Encrypt(data, key)
+	if err != nil {
+		return err
+	}
+
+	return osWriteFile(path, encrypted, 0o600)
+}
+
+// DecryptFile decrypts a file's contents in place.
+// Reads from the given path, decrypts the data, and writes it back.
+func DecryptFile(path string, key []byte) error {
+	data, err := osReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Skip if not encrypted
+	if !IsEncrypted(data) {
+		return nil
+	}
+
+	decrypted, err := Decrypt(data, key)
+	if err != nil {
+		return err
+	}
+
+	return osWriteFile(path, decrypted, 0o600)
+}
+
+// osReadFile is a wrapper for os.ReadFile to allow mocking in tests
+var osReadFile = os.ReadFile
+
+// osWriteFile is a wrapper for os.WriteFile to allow mocking in tests
+var osWriteFile = os.WriteFile
+
+// EncryptToBase64 encrypts data and returns the result as a base64 string.
+// Useful for embedding encrypted data in structured formats.
+func EncryptToBase64(plaintext, key []byte) (string, error) {
+	encrypted, err := Encrypt(plaintext, key)
+	if err != nil {
+		return "", err
+	}
+	return base64.StdEncoding.EncodeToString(encrypted), nil
+}
+
+// DecryptFromBase64 decrypts a base64-encoded ciphertext string.
+func DecryptFromBase64(base64Ciphertext string, key []byte) ([]byte, error) {
+	ciphertext, err := base64.StdEncoding.DecodeString(base64Ciphertext)
+	if err != nil {
+		return nil, err
+	}
+	return Decrypt(ciphertext, key)
+}

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -53,7 +53,8 @@ var (
 )
 
 // Encrypt encrypts plaintext data using AES-256-GCM with the provided key.
-// Returns the encrypted ciphertext (nonce + ciphertext + tag) or an error.
+// Returns the base64-encoded encrypted ciphertext (with YATTO_ENC prefix) as bytes,
+// making it safe for text-based storage (git-friendly).
 func Encrypt(plaintext, base64Key []byte) ([]byte, error) {
 	key, err := base64.StdEncoding.DecodeString(string(base64Key))
 	if err != nil {
@@ -86,11 +87,13 @@ func Encrypt(plaintext, base64Key []byte) ([]byte, error) {
 	copy(result, EncryptedFilePrefix)
 	copy(result[len(EncryptedFilePrefix):], ciphertext)
 
-	return result, nil
+	// Base64 encode for text-based storage (git-friendly)
+	return []byte(base64.StdEncoding.EncodeToString(result)), nil
 }
 
 // Decrypt decrypts ciphertext data using AES-256-GCM with the provided key.
-// The ciphertext should have been produced by Encrypt() and includes the nonce.
+// The ciphertext should have been produced by Encrypt() and is expected to be
+// base64-encoded bytes with the YATTO_ENC prefix.
 // Returns the decrypted plaintext or an error.
 func Decrypt(ciphertext, base64Key []byte) ([]byte, error) {
 	key, err := base64.StdEncoding.DecodeString(string(base64Key))
@@ -102,13 +105,19 @@ func Decrypt(ciphertext, base64Key []byte) ([]byte, error) {
 		return nil, ErrInvalidKey
 	}
 
+	// Base64 decode the input
+	decoded, err := base64.StdEncoding.DecodeString(string(ciphertext))
+	if err != nil {
+		return nil, ErrDecryptionFailed
+	}
+
 	// Check for encryption prefix
-	if len(ciphertext) < len(EncryptedFilePrefix) ||
-		string(ciphertext[:len(EncryptedFilePrefix)]) != EncryptedFilePrefix {
+	if len(decoded) < len(EncryptedFilePrefix) ||
+		string(decoded[:len(EncryptedFilePrefix)]) != EncryptedFilePrefix {
 		return nil, ErrNotEncrypted
 	}
 
-	actualCiphertext := ciphertext[len(EncryptedFilePrefix):]
+	actualCiphertext := decoded[len(EncryptedFilePrefix):]
 
 	block, err := aes.NewCipher(key)
 	if err != nil {
@@ -136,9 +145,20 @@ func Decrypt(ciphertext, base64Key []byte) ([]byte, error) {
 }
 
 // IsEncrypted checks if the given data has the encryption prefix.
+// The data can be either raw bytes or base64-encoded bytes.
 func IsEncrypted(data []byte) bool {
-	return len(data) >= len(EncryptedFilePrefix) &&
-		string(data[:len(EncryptedFilePrefix)]) == EncryptedFilePrefix
+	// Try direct check first (for raw bytes)
+	if len(data) >= len(EncryptedFilePrefix) &&
+		string(data[:len(EncryptedFilePrefix)]) == EncryptedFilePrefix {
+		return true
+	}
+	// Try base64 decode and check (for text-based storage)
+	if _, err := base64.StdEncoding.DecodeString(string(data)); err == nil {
+		decoded, _ := base64.StdEncoding.DecodeString(string(data))
+		return len(decoded) >= len(EncryptedFilePrefix) &&
+			string(decoded[:len(EncryptedFilePrefix)]) == EncryptedFilePrefix
+	}
+	return false
 }
 
 // GenerateKey generates a new random 32-byte key suitable for AES-256.
@@ -213,7 +233,8 @@ var osReadFile = os.ReadFile
 var osWriteFile = os.WriteFile
 
 // EncryptToBase64 encrypts data and returns the result as a base64 string.
-// Useful for embedding encrypted data in structured formats.
+// The output includes the YATTO_ENC prefix for identification.
+// Useful for storing encrypted data as text (git-friendly).
 func EncryptToBase64(plaintext, key []byte) (string, error) {
 	encrypted, err := Encrypt(plaintext, key)
 	if err != nil {
@@ -223,10 +244,20 @@ func EncryptToBase64(plaintext, key []byte) (string, error) {
 }
 
 // DecryptFromBase64 decrypts a base64-encoded ciphertext string.
+// The input should have been produced by EncryptToBase64 and includes the YATTO_ENC prefix.
 func DecryptFromBase64(base64Ciphertext string, key []byte) ([]byte, error) {
 	ciphertext, err := base64.StdEncoding.DecodeString(base64Ciphertext)
 	if err != nil {
 		return nil, err
 	}
 	return Decrypt(ciphertext, key)
+}
+
+// IsBase64Encrypted checks if the given base64 string, when decoded, has the encryption prefix.
+func IsBase64Encrypted(base64Data string) bool {
+	data, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil {
+		return false
+	}
+	return IsEncrypted(data)
 }

--- a/internal/encryption/encryption.go
+++ b/internal/encryption/encryption.go
@@ -54,7 +54,12 @@ var (
 
 // Encrypt encrypts plaintext data using AES-256-GCM with the provided key.
 // Returns the encrypted ciphertext (nonce + ciphertext + tag) or an error.
-func Encrypt(plaintext, key []byte) ([]byte, error) {
+func Encrypt(plaintext, base64Key []byte) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(string(base64Key))
+	if err != nil {
+		return nil, err
+	}
+
 	if len(key) != KeySize {
 		return nil, ErrInvalidKey
 	}
@@ -87,7 +92,12 @@ func Encrypt(plaintext, key []byte) ([]byte, error) {
 // Decrypt decrypts ciphertext data using AES-256-GCM with the provided key.
 // The ciphertext should have been produced by Encrypt() and includes the nonce.
 // Returns the decrypted plaintext or an error.
-func Decrypt(ciphertext, key []byte) ([]byte, error) {
+func Decrypt(ciphertext, base64Key []byte) ([]byte, error) {
+	key, err := base64.StdEncoding.DecodeString(string(base64Key))
+	if err != nil {
+		return nil, err
+	}
+
 	if len(key) != KeySize {
 		return nil, ErrInvalidKey
 	}

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -68,7 +68,7 @@ func ReadProjectsFromFS(v *viper.Viper) []items.Project {
 		// Decrypt if encrypted and encryption is enabled
 		if v.GetBool("encryption.enable") && encryption.IsEncrypted(projectFile) {
 			keyPath := v.GetString("encryption.key_path")
-			key, err := os.ReadFile(keyPath)
+			key, err := os.ReadFile(keyPath) //nolint:gosec
 			if err != nil {
 				panic(err)
 			}
@@ -130,7 +130,7 @@ func AllLabels(v *viper.Viper) map[string]int {
 		// Decrypt if encrypted and encryption is enabled
 		if v.GetBool("encryption.enable") && encryption.IsEncrypted(data) {
 			keyPath := v.GetString("encryption.key_path")
-			key, err := os.ReadFile(keyPath)
+			key, err := os.ReadFile(keyPath) //nolint:gosec
 			if err != nil {
 				panic(err)
 			}

--- a/internal/helpers/helpers.go
+++ b/internal/helpers/helpers.go
@@ -33,6 +33,7 @@ import (
 	"strings"
 
 	"github.com/handlebargh/yatto/internal/colors"
+	"github.com/handlebargh/yatto/internal/encryption"
 	"github.com/handlebargh/yatto/internal/items"
 	"github.com/spf13/viper"
 )
@@ -62,6 +63,19 @@ func ReadProjectsFromFS(v *viper.Viper) []items.Project {
 		projectFile, err := root.ReadFile(filepath.Join(entry.Name(), "project.json"))
 		if err != nil {
 			panic(err)
+		}
+
+		// Decrypt if encrypted and encryption is enabled
+		if v.GetBool("encryption.enable") && encryption.IsEncrypted(projectFile) {
+			keyPath := v.GetString("encryption.key_path")
+			key, err := os.ReadFile(keyPath)
+			if err != nil {
+				panic(err)
+			}
+			projectFile, err = encryption.Decrypt(projectFile, key)
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		var project items.Project
@@ -111,6 +125,19 @@ func AllLabels(v *viper.Viper) map[string]int {
 		data, err := root.ReadFile(path)
 		if err != nil {
 			panic(fmt.Sprintf("unexpected read error for %s: %v", path, err))
+		}
+
+		// Decrypt if encrypted and encryption is enabled
+		if v.GetBool("encryption.enable") && encryption.IsEncrypted(data) {
+			keyPath := v.GetString("encryption.key_path")
+			key, err := os.ReadFile(keyPath)
+			if err != nil {
+				panic(err)
+			}
+			data, err = encryption.Decrypt(data, key)
+			if err != nil {
+				panic(err)
+			}
 		}
 
 		var task struct {

--- a/internal/items/project.go
+++ b/internal/items/project.go
@@ -31,6 +31,7 @@ import (
 
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+	"github.com/handlebargh/yatto/internal/encryption"
 	"github.com/mattn/go-runewidth"
 	"github.com/spf13/viper"
 )
@@ -127,6 +128,19 @@ func (p *Project) ReadTasksFromFS(v *viper.Viper) []Task {
 			panic(err)
 		}
 
+		// Decrypt if encrypted and encryption is enabled
+		if v.GetBool("encryption.enable") && encryption.IsEncrypted(fileContent) {
+			keyPath := v.GetString("encryption.key_path")
+			key, err := os.ReadFile(keyPath)
+			if err != nil {
+				panic(err)
+			}
+			fileContent, err = encryption.Decrypt(fileContent, key)
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		var task Task
 		if err := json.Unmarshal(fileContent, &task); err != nil {
 			panic(err)
@@ -166,6 +180,7 @@ func (p *Project) MarshalProject() []byte {
 // WriteProjectJSON writes the given project JSON to disk as project.json
 // inside the project's directory. Ensures the directory exists.
 // Returns a Tea message indicating success or error.
+// If encryption is enabled in the config, the data will be encrypted before writing.
 func (p *Project) WriteProjectJSON(v *viper.Viper, json []byte, kind string) tea.Cmd {
 	return func() tea.Msg {
 		root, err := os.OpenRoot(v.GetString("storage.path"))
@@ -180,6 +195,20 @@ func (p *Project) WriteProjectJSON(v *viper.Viper, json []byte, kind string) tea
 		}
 
 		file := filepath.Join(p.ID, "project.json")
+
+		// Encrypt if enabled
+		if v.GetBool("encryption.enable") {
+			keyPath := v.GetString("encryption.key_path")
+			key, err := os.ReadFile(keyPath)
+			if err != nil {
+				return WriteProjectJSONErrorMsg{err}
+			}
+			json, err = encryption.Encrypt(json, key)
+			if err != nil {
+				return WriteProjectJSONErrorMsg{err}
+			}
+		}
+
 		if err := root.WriteFile(file, json, 0o600); err != nil {
 			return WriteProjectJSONErrorMsg{err}
 		}
@@ -216,6 +245,19 @@ func (p *Project) NumOfTasks(v *viper.Viper) (int, int, int, error) {
 		data, err := root.ReadFile(filePath)
 		if err != nil {
 			continue
+		}
+
+		// Decrypt if encrypted and encryption is enabled
+		if v.GetBool("encryption.enable") && encryption.IsEncrypted(data) {
+			keyPath := v.GetString("encryption.key_path")
+			key, err := os.ReadFile(keyPath)
+			if err != nil {
+				return 0, 0, 0, err
+			}
+			data, err = encryption.Decrypt(data, key)
+			if err != nil {
+				return 0, 0, 0, err
+			}
 		}
 
 		var t struct {

--- a/internal/items/project.go
+++ b/internal/items/project.go
@@ -131,7 +131,7 @@ func (p *Project) ReadTasksFromFS(v *viper.Viper) []Task {
 		// Decrypt if encrypted and encryption is enabled
 		if v.GetBool("encryption.enable") && encryption.IsEncrypted(fileContent) {
 			keyPath := v.GetString("encryption.key_path")
-			key, err := os.ReadFile(keyPath)
+			key, err := os.ReadFile(keyPath) //nolint:gosec
 			if err != nil {
 				panic(err)
 			}
@@ -199,7 +199,7 @@ func (p *Project) WriteProjectJSON(v *viper.Viper, json []byte, kind string) tea
 		// Encrypt if enabled
 		if v.GetBool("encryption.enable") {
 			keyPath := v.GetString("encryption.key_path")
-			key, err := os.ReadFile(keyPath)
+			key, err := os.ReadFile(keyPath) //nolint:gosec
 			if err != nil {
 				return WriteProjectJSONErrorMsg{err}
 			}
@@ -250,7 +250,7 @@ func (p *Project) NumOfTasks(v *viper.Viper) (int, int, int, error) {
 		// Decrypt if encrypted and encryption is enabled
 		if v.GetBool("encryption.enable") && encryption.IsEncrypted(data) {
 			keyPath := v.GetString("encryption.key_path")
-			key, err := os.ReadFile(keyPath)
+			key, err := os.ReadFile(keyPath) //nolint:gosec
 			if err != nil {
 				return 0, 0, 0, err
 			}

--- a/internal/items/task.go
+++ b/internal/items/task.go
@@ -37,6 +37,7 @@ import (
 
 	"charm.land/bubbles/v2/list"
 	tea "charm.land/bubbletea/v2"
+	"github.com/handlebargh/yatto/internal/encryption"
 	"github.com/mattn/go-runewidth"
 	"github.com/spf13/viper"
 )
@@ -233,6 +234,7 @@ func (t *Task) MarshalTask() []byte {
 
 // WriteTaskJSON writes the given task JSON to disk under the project directory,
 // using the task's ID as the filename. Returns a Tea message on success or error.
+// If encryption is enabled in the config, the data will be encrypted before writing.
 func (t *Task) WriteTaskJSON(v *viper.Viper, json []byte, p Project, kind string) tea.Cmd {
 	return func() tea.Msg {
 		root, err := os.OpenRoot(v.GetString("storage.path"))
@@ -242,6 +244,19 @@ func (t *Task) WriteTaskJSON(v *viper.Viper, json []byte, p Project, kind string
 		defer root.Close() //nolint:errcheck
 
 		file := filepath.Join(p.ID, t.ID+".json")
+
+		// Encrypt if enabled
+		if v.GetBool("encryption.enable") {
+			keyPath := v.GetString("encryption.key_path")
+			key, err := os.ReadFile(keyPath)
+			if err != nil {
+				return WriteTaskJSONErrorMsg{err}
+			}
+			json, err = encryption.Encrypt(json, key)
+			if err != nil {
+				return WriteTaskJSONErrorMsg{err}
+			}
+		}
 
 		if err := root.WriteFile(file, json, 0o600); err != nil {
 			return WriteTaskJSONErrorMsg{err}

--- a/internal/items/task.go
+++ b/internal/items/task.go
@@ -248,7 +248,7 @@ func (t *Task) WriteTaskJSON(v *viper.Viper, json []byte, p Project, kind string
 		// Encrypt if enabled
 		if v.GetBool("encryption.enable") {
 			keyPath := v.GetString("encryption.key_path")
-			key, err := os.ReadFile(keyPath)
+			key, err := os.ReadFile(keyPath) //nolint:gosec
 			if err != nil {
 				return WriteTaskJSONErrorMsg{err}
 			}

--- a/internal/models/projectForm.go
+++ b/internal/models/projectForm.go
@@ -33,7 +33,6 @@ import (
 	"github.com/handlebargh/yatto/internal/colors"
 	"github.com/handlebargh/yatto/internal/items"
 	"github.com/handlebargh/yatto/internal/storage"
-	"github.com/handlebargh/yatto/internal/vcs"
 	"github.com/mattn/go-runewidth"
 )
 
@@ -187,15 +186,12 @@ func (m projectFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		m.listModel.spinning = true
+		m.listModel.commitMessage = fmt.Sprintf("%s: %s", action, m.project.Title)
+		m.listModel.commitPath = filepath.Join(m.project.ID, "project.json")
 		cmds = append(
 			cmds,
 			m.listModel.spinner.Tick,
 			m.project.WriteProjectJSON(m.listModel.config, json, action),
-			vcs.CommitCmd(
-				m.listModel.config,
-				fmt.Sprintf("%s: %s", action, m.project.Title),
-				filepath.Join(m.project.ID, "project.json"),
-			),
 		)
 
 		m.listModel.status = ""

--- a/internal/models/projectList.go
+++ b/internal/models/projectList.go
@@ -367,6 +367,9 @@ type ProjectListModel struct {
 	progressOrange progress.Model
 	progressYellow progress.Model
 	progressGreen  progress.Model
+	// Fields for tracking pending commit after project write (from form)
+	commitMessage string
+	commitPath    string
 }
 
 // InitialProjectListModel returns an initialized projectListModel
@@ -524,17 +527,35 @@ func (m ProjectListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "create":
 			m.list.InsertItem(0, &msg.Project)
 			m.status = "🗸  Project created ― committing changes"
-			return m, items.LoadAllTaskStatsCmd(m.config, m.allProjects())
 
 		case "update":
 			m.status = "🗸  Project updated ― committing changes"
-			return m, items.LoadAllTaskStatsCmd(m.config, m.allProjects())
 		}
-		return m, nil
+
+		// If we have a pending commit (from project create/update via form),
+		// trigger it now that the file has been written
+		if m.commitPath != "" && (msg.Kind == "create" || msg.Kind == "update") {
+			cmds := []tea.Cmd{
+				vcs.CommitCmd(
+					m.config,
+					m.commitMessage,
+					m.commitPath,
+				),
+				items.LoadAllTaskStatsCmd(m.config, m.allProjects()),
+			}
+			// Clear the pending commit info
+			m.commitMessage = ""
+			m.commitPath = ""
+			return m, tea.Batch(cmds...)
+		}
+
+		return m, items.LoadAllTaskStatsCmd(m.config, m.allProjects())
 
 	case items.WriteProjectJSONErrorMsg:
-		m.mode = 2
+		m.mode = modeBackendError
 		m.err = msg.Err
+		m.cmdOutput = msg.Err.Error()
+		m.spinning = false
 		return m, nil
 
 	case items.ProjectDeleteDoneMsg:

--- a/internal/models/taskForm.go
+++ b/internal/models/taskForm.go
@@ -351,15 +351,12 @@ func (m taskFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			m.listModel.spinning = true
+			m.listModel.commitMessage = fmt.Sprintf("%s: %s", action, m.task.Title)
+			m.listModel.commitPath = taskPath
 			cmds = append(
 				cmds,
 				m.listModel.spinner.Tick,
 				m.task.WriteTaskJSON(m.listModel.projectModel.config, json, *m.listModel.project, action),
-				vcs.CommitCmd(
-					m.listModel.projectModel.config,
-					fmt.Sprintf("%s: %s", action, m.task.Title),
-					taskPath,
-				),
 			)
 
 			m.listModel.status = ""

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -430,7 +430,7 @@ func (d customTaskDelegate) Render(w io.Writer, m list.Model, index int, item li
 	} else {
 		// Blank line for consistent spacing
 		sb.WriteString(borderV)
-		sb.WriteString(strings.Repeat(" ", contentWidth+2))
+		sb.WriteString(strings.Repeat(" ", contentWidth))
 		sb.WriteString(borderV)
 		sb.WriteString("\n")
 	}

--- a/internal/models/taskList.go
+++ b/internal/models/taskList.go
@@ -473,6 +473,9 @@ type taskListModel struct {
 	width, height int
 	selectedItems map[string]*items.Task
 	showArchived  bool
+	// Fields for tracking pending commit after task write (from form)
+	commitMessage string
+	commitPath    string
 }
 
 // newTaskListModel creates a new taskListModel for the given project.
@@ -643,11 +646,30 @@ func (m taskListModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		default:
 			return m, nil
 		}
+
+		// If we have a pending commit (from single task create/update via form),
+		// trigger it now that the file has been written
+		if m.commitPath != "" && (msg.Kind == "create" || msg.Kind == "update") {
+			cmds := []tea.Cmd{
+				vcs.CommitCmd(
+					m.projectModel.config,
+					m.commitMessage,
+					m.commitPath,
+				),
+			}
+			// Clear the pending commit info
+			m.commitMessage = ""
+			m.commitPath = ""
+			return m, tea.Batch(cmds...)
+		}
+
 		return m, nil
 
 	case items.WriteTaskJSONErrorMsg:
-		m.mode = 2
+		m.mode = modeBackendError
 		m.err = msg.Err
+		m.cmdOutput = msg.Err.Error()
+		m.spinning = false
 		return m, nil
 
 	case items.TaskDeleteDoneMsg:


### PR DESCRIPTION
## Type of Change

- New feature (non-breaking change)
  
## Description

This PR adds task encryption via AES256-GCM. yatto gets a new command `yatto key generate` that will generate a 32 byte base64 encoded encryption key. The encryption primitives all come from the stdlib.